### PR TITLE
Add operation duration and timeout metrics

### DIFF
--- a/util/metrics/metrics.go
+++ b/util/metrics/metrics.go
@@ -152,6 +152,25 @@ var (
 		[]string{"shard"},
 	)
 
+	// OperationTimeoutsTotal tracks the total number of operation timeouts
+	OperationTimeoutsTotal = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "goverse_operation_timeouts_total",
+			Help: "Total number of operation timeouts by node and operation type",
+		},
+		[]string{"node_addr", "operation"},
+	)
+
+	// OperationDurationSeconds tracks the duration of operations in seconds
+	OperationDurationSeconds = promauto.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:    "goverse_operation_duration_seconds",
+			Help:    "Duration of operations in seconds by node, operation type, and status",
+			Buckets: []float64{0.001, 0.005, 0.01, 0.05, 0.1, 0.5, 1, 5, 10, 30},
+		},
+		[]string{"node_addr", "operation", "status"},
+	)
+
 	// ShardMappingWriteFailuresTotal tracks the total number of shard mapping write failures by error type
 	ShardMappingWriteFailuresTotal = promauto.NewCounterVec(
 		prometheus.CounterOpts{
@@ -267,4 +286,14 @@ func RecordShardMethodCall(shard int) {
 // RecordShardMappingWriteFailure increments the shard mapping write failure counter by error type
 func RecordShardMappingWriteFailure(errorType string) {
 	ShardMappingWriteFailuresTotal.WithLabelValues(errorType).Inc()
+}
+
+// RecordOperationTimeout increments the operation timeout counter for a given node and operation
+func RecordOperationTimeout(nodeAddr, operation string) {
+	OperationTimeoutsTotal.WithLabelValues(nodeAddr, operation).Inc()
+}
+
+// RecordOperationDuration records the duration of an operation in seconds
+func RecordOperationDuration(nodeAddr, operation, status string, duration float64) {
+	OperationDurationSeconds.WithLabelValues(nodeAddr, operation, status).Observe(duration)
 }

--- a/util/metrics/operation_metrics_test.go
+++ b/util/metrics/operation_metrics_test.go
@@ -1,0 +1,42 @@
+package metrics
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+)
+
+func TestRecordOperationTimeout(t *testing.T) {
+	before := testutil.ToFloat64(OperationTimeoutsTotal.WithLabelValues("node1:8080", "call_object"))
+	RecordOperationTimeout("node1:8080", "call_object")
+	after := testutil.ToFloat64(OperationTimeoutsTotal.WithLabelValues("node1:8080", "call_object"))
+	if after != before+1 {
+		t.Fatalf("expected counter to increment by 1, got delta %f", after-before)
+	}
+}
+
+func TestRecordOperationDuration(t *testing.T) {
+	RecordOperationDuration("node2:8080", "create_object", "success", 0.123)
+
+	expected := `
+# HELP goverse_operation_duration_seconds Duration of operations in seconds by node, operation type, and status
+# TYPE goverse_operation_duration_seconds histogram
+goverse_operation_duration_seconds_bucket{node_addr="node2:8080",operation="create_object",status="success",le="0.001"} 0
+goverse_operation_duration_seconds_bucket{node_addr="node2:8080",operation="create_object",status="success",le="0.005"} 0
+goverse_operation_duration_seconds_bucket{node_addr="node2:8080",operation="create_object",status="success",le="0.01"} 0
+goverse_operation_duration_seconds_bucket{node_addr="node2:8080",operation="create_object",status="success",le="0.05"} 0
+goverse_operation_duration_seconds_bucket{node_addr="node2:8080",operation="create_object",status="success",le="0.1"} 0
+goverse_operation_duration_seconds_bucket{node_addr="node2:8080",operation="create_object",status="success",le="0.5"} 1
+goverse_operation_duration_seconds_bucket{node_addr="node2:8080",operation="create_object",status="success",le="1"} 1
+goverse_operation_duration_seconds_bucket{node_addr="node2:8080",operation="create_object",status="success",le="5"} 1
+goverse_operation_duration_seconds_bucket{node_addr="node2:8080",operation="create_object",status="success",le="10"} 1
+goverse_operation_duration_seconds_bucket{node_addr="node2:8080",operation="create_object",status="success",le="30"} 1
+goverse_operation_duration_seconds_bucket{node_addr="node2:8080",operation="create_object",status="success",le="+Inf"} 1
+goverse_operation_duration_seconds_sum{node_addr="node2:8080",operation="create_object",status="success"} 0.123
+goverse_operation_duration_seconds_count{node_addr="node2:8080",operation="create_object",status="success"} 1
+`
+	if err := testutil.CollectAndCompare(OperationDurationSeconds, strings.NewReader(expected), "goverse_operation_duration_seconds"); err != nil {
+		t.Fatalf("unexpected metric output: %v", err)
+	}
+}


### PR DESCRIPTION
Add metrics primitives for tracking operation durations and timeouts.

## Changes
- `goverse_operation_timeouts_total` counter vec (labels: node_addr, operation)
- `goverse_operation_duration_seconds` histogram vec (labels: node_addr, operation, status)
- `RecordOperationTimeout()` and `RecordOperationDuration()` helper functions
- Tests using prometheus/testutil

No wiring to cluster.go yet — metrics only.