### PR TITLE
Add watch reconnection with exponential backoff

### DIFF
--- a/cluster/consensusmanager/consensusmanager.go
+++ b/cluster/consensusmanager/consensusmanager.go
@@ -486,9 +486,13 @@ func (cm *ConsensusManager) StartWatch(ctx context.Context) error {
 	cm.watchCtx, cm.watchCancel = context.WithCancel(ctx)
 	cm.watchStarted = true
 
+	// Capture the context for this watch session so the goroutine is tied
+	// to a single lifecycle even if StopWatch/StartWatch is called quickly.
+	watchCtx := cm.watchCtx
+
 	// Start watching the entire /goverse prefix
 	prefix := cm.etcdManager.GetPrefix()
-	go cm.watchPrefix(prefix)
+	go cm.watchPrefix(watchCtx, prefix)
 
 	return nil
 }
@@ -506,7 +510,7 @@ func (cm *ConsensusManager) StopWatch() {
 // watchPrefix watches the entire etcd prefix for changes.
 // If the watch channel closes (e.g. network disconnect, etcd restart, compaction),
 // it reloads the full cluster state and re-establishes the watch with exponential backoff.
-func (cm *ConsensusManager) watchPrefix(prefix string) {
+func (cm *ConsensusManager) watchPrefix(ctx context.Context, prefix string) {
 	const (
 		initialBackoff = 1 * time.Second
 		maxBackoff     = 30 * time.Second
@@ -514,7 +518,7 @@ func (cm *ConsensusManager) watchPrefix(prefix string) {
 	backoff := initialBackoff
 
 	for {
-		err := cm.watchPrefixOnce(prefix)
+		err := cm.watchPrefixOnce(ctx, prefix)
 		if err == nil {
 			// Context was cancelled — clean shutdown
 			return
@@ -522,7 +526,7 @@ func (cm *ConsensusManager) watchPrefix(prefix string) {
 
 		// Check if context is done before retrying
 		select {
-		case <-cm.watchCtx.Done():
+		case <-ctx.Done():
 			cm.logger.Infof("Watch stopped during reconnection")
 			return
 		default:
@@ -533,7 +537,7 @@ func (cm *ConsensusManager) watchPrefix(prefix string) {
 		// Wait with backoff
 		timer := time.NewTimer(backoff)
 		select {
-		case <-cm.watchCtx.Done():
+		case <-ctx.Done():
 			timer.Stop()
 			cm.logger.Infof("Watch stopped during backoff")
 			return
@@ -542,7 +546,7 @@ func (cm *ConsensusManager) watchPrefix(prefix string) {
 
 		// Reload full state before re-establishing watch
 		cm.logger.Infof("Reloading cluster state before watch reconnection")
-		state, loadErr := cm.loadClusterStateFromEtcd(cm.watchCtx)
+		state, loadErr := cm.loadClusterStateFromEtcd(ctx)
 		if loadErr != nil {
 			cm.logger.Errorf("Failed to reload cluster state: %v", loadErr)
 			// Increase backoff and retry
@@ -568,7 +572,7 @@ func (cm *ConsensusManager) watchPrefix(prefix string) {
 
 // watchPrefixOnce runs a single watch session. Returns nil if context was cancelled
 // (clean shutdown), or an error describing why the watch ended.
-func (cm *ConsensusManager) watchPrefixOnce(prefix string) error {
+func (cm *ConsensusManager) watchPrefixOnce(ctx context.Context, prefix string) error {
 	client := cm.etcdManager.GetClient()
 	if client == nil {
 		return fmt.Errorf("etcd client not available")
@@ -585,12 +589,12 @@ func (cm *ConsensusManager) watchPrefixOnce(prefix string) error {
 	leaderKey := prefix + "/leader"
 
 	// Watch from the next revision after our load to prevent missing events
-	watchChan := client.Watch(cm.watchCtx, prefix, clientv3.WithPrefix(), clientv3.WithRev(revision+1))
+	watchChan := client.Watch(ctx, prefix, clientv3.WithPrefix(), clientv3.WithRev(revision+1))
 
 	cm.logger.Infof("Started watching prefix %s from revision %d", prefix, revision+1)
 	for {
 		select {
-		case <-cm.watchCtx.Done():
+		case <-ctx.Done():
 			cm.logger.Infof("Watch stopped")
 			return nil
 		case watchResp, ok := <-watchChan:

--- a/cluster/consensusmanager/watch_reconnect_test.go
+++ b/cluster/consensusmanager/watch_reconnect_test.go
@@ -1,0 +1,118 @@
+package consensusmanager
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/xiaonanln/goverse/cluster/etcdmanager"
+	"github.com/xiaonanln/goverse/cluster/shardlock"
+	"github.com/xiaonanln/goverse/util/testutil"
+)
+
+// TestWatchReconnectsOnChannelClose verifies that the watch can be stopped
+// and restarted, and that it picks up new events after restart.
+func TestWatchReconnectsOnChannelClose(t *testing.T) {
+	testPrefix := testutil.PrepareEtcdPrefix(t, "localhost:2379")
+
+	mgr, err := etcdmanager.NewEtcdManager("localhost:2379", testPrefix)
+	if err != nil {
+		t.Fatalf("Failed to create etcd manager: %v", err)
+	}
+	err = mgr.Connect()
+	if err != nil {
+		t.Skipf("etcd not available: %v", err)
+		return
+	}
+	defer mgr.Close()
+
+	cm := NewConsensusManager(mgr, shardlock.NewShardLock(testNumShards), 0, "", testNumShards)
+
+	ctx := context.Background()
+	err = cm.Initialize(ctx)
+	if err != nil {
+		t.Fatalf("Failed to initialize: %v", err)
+	}
+
+	// Start the watch
+	err = cm.StartWatch(ctx)
+	if err != nil {
+		t.Fatalf("Failed to start watch: %v", err)
+	}
+
+	// Let watch establish
+	time.Sleep(100 * time.Millisecond)
+
+	// Cancel and restart watch to verify it can be stopped and restarted
+	cm.StopWatch()
+	time.Sleep(100 * time.Millisecond)
+
+	// Restart — this exercises that the state is clean after stop
+	err = cm.StartWatch(ctx)
+	if err != nil {
+		t.Fatalf("Failed to restart watch: %v", err)
+	}
+
+	// Verify watch is running by writing a key and checking it's picked up
+	client := mgr.GetClient()
+	nodeKey := testPrefix + "/nodes/test-reconnect-node"
+	_, err = client.Put(ctx, nodeKey, "test-addr:1234")
+	if err != nil {
+		t.Fatalf("Failed to put node key: %v", err)
+	}
+
+	// Wait for the watch event to be processed
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		cm.mu.RLock()
+		_, exists := cm.state.Nodes["test-addr:1234"]
+		cm.mu.RUnlock()
+		if exists {
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+
+	cm.mu.RLock()
+	_, exists := cm.state.Nodes["test-addr:1234"]
+	cm.mu.RUnlock()
+	if !exists {
+		t.Fatalf("Watch did not pick up node addition after restart")
+	}
+
+	cm.StopWatch()
+}
+
+// TestWatchPrefixOnceReturnsNilOnCancel tests that watchPrefixOnce
+// returns nil (clean shutdown) when the context is cancelled.
+func TestWatchPrefixOnceReturnsNilOnCancel(t *testing.T) {
+	testPrefix := testutil.PrepareEtcdPrefix(t, "localhost:2379")
+
+	mgr, err := etcdmanager.NewEtcdManager("localhost:2379", testPrefix)
+	if err != nil {
+		t.Fatalf("Failed to create etcd manager: %v", err)
+	}
+	err = mgr.Connect()
+	if err != nil {
+		t.Skipf("etcd not available: %v", err)
+		return
+	}
+	defer mgr.Close()
+
+	cm := NewConsensusManager(mgr, shardlock.NewShardLock(testNumShards), 0, "", testNumShards)
+
+	ctx := context.Background()
+	err = cm.Initialize(ctx)
+	if err != nil {
+		t.Fatalf("Failed to initialize: %v", err)
+	}
+
+	// Set up watch context and cancel it to force watchPrefixOnce to return nil (clean shutdown)
+	cm.watchCtx, cm.watchCancel = context.WithCancel(ctx)
+	cm.watchCancel() // cancel immediately
+
+	result := cm.watchPrefixOnce(testPrefix)
+	if result != nil {
+		t.Fatalf("Expected nil (clean shutdown) but got error: %v", result)
+	}
+}

--- a/cluster/consensusmanager/watch_reconnect_test.go
+++ b/cluster/consensusmanager/watch_reconnect_test.go
@@ -108,10 +108,10 @@ func TestWatchPrefixOnceReturnsNilOnCancel(t *testing.T) {
 	}
 
 	// Set up watch context and cancel it to force watchPrefixOnce to return nil (clean shutdown)
-	cm.watchCtx, cm.watchCancel = context.WithCancel(ctx)
-	cm.watchCancel() // cancel immediately
+	watchCtx, watchCancel := context.WithCancel(ctx)
+	watchCancel() // cancel immediately
 
-	result := cm.watchPrefixOnce(testPrefix)
+	result := cm.watchPrefixOnce(watchCtx, testPrefix)
 	if result != nil {
 		t.Fatalf("Expected nil (clean shutdown) but got error: %v", result)
 	}


### PR DESCRIPTION
## Problem

When the etcd watch channel closes (network disconnect, etcd restart, compaction), the `watchPrefix` goroutine in `ConsensusManager` exits permanently. After that, the node's in-memory cluster state becomes permanently stale — it stops seeing node joins/leaves, shard changes, and leader updates.

## Solution

Split `watchPrefix` into two functions:
- **`watchPrefix`** — outer retry loop with exponential backoff (1s → 30s max)
- **`watchPrefixOnce`** — single watch session that returns an error on disconnect or nil on clean shutdown

On watch disconnection:
1. Wait with exponential backoff
2. Reload full cluster state via `loadClusterStateFromEtcd`
3. Re-establish watch from the new revision
4. Notify listeners of refreshed state
5. Reset backoff on success

## Files Changed

- `cluster/consensusmanager/consensusmanager.go` — reconnection logic
- `cluster/consensusmanager/watch_reconnect_test.go` — tests (require etcd)

## Milestone

Part of v0.1.0 — item #5 "Watch Reconnection on Disconnect" (P1).