### PR TITLE
Add graceful shutdown mode (Clean/Quick)

### DIFF
--- a/cluster/cluster_shutdown_test.go
+++ b/cluster/cluster_shutdown_test.go
@@ -1,0 +1,200 @@
+package cluster
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/xiaonanln/goverse/cluster/consensusmanager"
+	"github.com/xiaonanln/goverse/node"
+	"github.com/xiaonanln/goverse/util/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCluster_Stop_DefaultsToQuickMode(t *testing.T) {
+	etcdManager, cleanup := testutil.SetupTestEtcd(t)
+	defer cleanup()
+
+	nodeAddr := "test-node:1234"
+	n := node.NewNode(nodeAddr, 8)
+
+	config := Config{
+		EtcdAddress: etcdManager.GetAddress(),
+		EtcdPrefix:  etcdManager.GetPrefix(),
+		NumShards:   8,
+	}
+
+	cluster, err := NewClusterWithNode(config, n)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	err = cluster.Start(ctx, n)
+	require.NoError(t, err)
+
+	// Test that Stop() uses quick mode by default (should complete immediately)
+	start := time.Now()
+	err = cluster.Stop(ctx)
+	duration := time.Since(start)
+	
+	assert.NoError(t, err)
+	// Quick shutdown should be very fast (less than 1 second)
+	assert.Less(t, duration, 1*time.Second, "Quick shutdown should complete quickly")
+}
+
+func TestCluster_StopWithMode_QuickMode(t *testing.T) {
+	etcdManager, cleanup := testutil.SetupTestEtcd(t)
+	defer cleanup()
+
+	nodeAddr := "test-node:1234"
+	n := node.NewNode(nodeAddr, 8)
+
+	config := Config{
+		EtcdAddress: etcdManager.GetAddress(),
+		EtcdPrefix:  etcdManager.GetPrefix(),
+		NumShards:   8,
+	}
+
+	cluster, err := NewClusterWithNode(config, n)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	err = cluster.Start(ctx, n)
+	require.NoError(t, err)
+
+	// Test explicit quick mode
+	start := time.Now()
+	err = cluster.StopWithMode(ctx, consensusmanager.ShutdownModeQuick)
+	duration := time.Since(start)
+	
+	assert.NoError(t, err)
+	assert.Less(t, duration, 1*time.Second, "Quick shutdown should complete quickly")
+}
+
+func TestCluster_StopWithMode_CleanMode_NoShards(t *testing.T) {
+	etcdManager, cleanup := testutil.SetupTestEtcd(t)
+	defer cleanup()
+
+	nodeAddr := "test-node:1234"
+	n := node.NewNode(nodeAddr, 8)
+
+	config := Config{
+		EtcdAddress: etcdManager.GetAddress(),
+		EtcdPrefix:  etcdManager.GetPrefix(),
+		NumShards:   8,
+	}
+
+	cluster, err := NewClusterWithNode(config, n)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	err = cluster.Start(ctx, n)
+	require.NoError(t, err)
+
+	// Test clean mode with no shards (should complete quickly since nothing to release)
+	start := time.Now()
+	err = cluster.StopWithMode(ctx, consensusmanager.ShutdownModeClean)
+	duration := time.Since(start)
+	
+	assert.NoError(t, err)
+	// Should still be fast when no shards to release
+	assert.Less(t, duration, 2*time.Second, "Clean shutdown with no shards should be relatively quick")
+}
+
+func TestCluster_StopWithMode_CleanMode_WithShards(t *testing.T) {
+	etcdManager, cleanup := testutil.SetupTestEtcd(t)
+	defer cleanup()
+
+	nodeAddr := "test-node:1234"
+	otherNodeAddr := "other-node:5678"
+	
+	// Set up first cluster/node
+	n1 := node.NewNode(nodeAddr, 8)
+	config := Config{
+		EtcdAddress: etcdManager.GetAddress(),
+		EtcdPrefix:  etcdManager.GetPrefix(),
+		NumShards:   8,
+	}
+
+	cluster1, err := NewClusterWithNode(config, n1)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	err = cluster1.Start(ctx, n1)
+	require.NoError(t, err)
+	
+	// Set up second cluster/node to claim released shards
+	n2 := node.NewNode(otherNodeAddr, 8)
+	cluster2, err := NewClusterWithNode(config, n2)
+	require.NoError(t, err)
+	
+	err = cluster2.Start(ctx, n2)
+	require.NoError(t, err)
+	defer cluster2.Stop(ctx)
+
+	// Wait for both nodes to be ready and have claimed some shards
+	require.Eventually(t, func() bool {
+		return cluster1.IsReady() && cluster2.IsReady()
+	}, 10*time.Second, 100*time.Millisecond, "Both clusters should become ready")
+
+	// Give some time for shard assignment and claiming
+	time.Sleep(2 * time.Second)
+
+	// Test clean shutdown - should release shards and wait for handoff
+	shutdownCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+	
+	err = cluster1.StopWithMode(shutdownCtx, consensusmanager.ShutdownModeClean)
+	assert.NoError(t, err)
+}
+
+func TestCluster_StopWithMode_GateIgnoresShutdownMode(t *testing.T) {
+	etcdManager, cleanup := testutil.SetupTestEtcd(t)
+	defer cleanup()
+
+	gateAddr := "test-gate:1234"
+	
+	// Create a cluster with a gate (not a node)
+	config := Config{
+		EtcdAddress: etcdManager.GetAddress(),
+		EtcdPrefix:  etcdManager.GetPrefix(),
+		NumShards:   8,
+	}
+
+	// Use NewClusterWithGate instead of NewClusterWithNode
+	// First create a basic gate - we'll use a mock since gate creation is complex
+	gw := &mockGate{address: gateAddr}
+	
+	cluster, err := NewClusterWithGate(config, gw)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	
+	// Test that gates ignore shutdown mode (both should behave the same)
+	err = cluster.StopWithMode(ctx, consensusmanager.ShutdownModeQuick)
+	assert.NoError(t, err)
+	
+	// Create another cluster instance for clean mode test
+	cluster2, err := NewClusterWithGate(config, gw)
+	require.NoError(t, err)
+	
+	err = cluster2.StopWithMode(ctx, consensusmanager.ShutdownModeClean) 
+	assert.NoError(t, err)
+}
+
+// mockGate is a minimal mock implementation for testing
+type mockGate struct {
+	address string
+}
+
+func (m *mockGate) GetAdvertiseAddress() string {
+	return m.address
+}
+
+func (m *mockGate) Start(ctx context.Context) error {
+	return nil
+}
+
+func (m *mockGate) Stop() error {
+	return nil
+}

--- a/cluster/consensusmanager/consensusmanager.go
+++ b/cluster/consensusmanager/consensusmanager.go
@@ -1913,11 +1913,10 @@ func (cm *ConsensusManager) identifyOwnedShards(localNode string) map[int]ShardI
 	shardsToRelease := make(map[int]ShardInfo)
 	for shardID, shardInfo := range cm.state.ShardMapping.Shards {
 		if shardInfo.CurrentNode == localNode {
-			// Release this shard by clearing both CurrentNode and TargetNode
-			// so other nodes can claim it via ClaimShardsForNode
-			released := shardInfo.WithCurrentNode("")
-			released.TargetNode = ""
-			shardsToRelease[shardID] = released
+			// Release this shard by clearing CurrentNode only.
+			// TargetNode is managed by the leader — after this node unregisters,
+			// the leader will detect TargetNode pointing to a dead node and reassign.
+			shardsToRelease[shardID] = shardInfo.WithCurrentNode("")
 		}
 	}
 	

--- a/cluster/consensusmanager/consensusmanager.go
+++ b/cluster/consensusmanager/consensusmanager.go
@@ -27,7 +27,31 @@ import (
 const (
 	// defaultClusterStateStabilityDuration is the default duration to consider the cluster state stable
 	defaultClusterStateStabilityDuration = 10 * time.Second
+	// defaultCleanShutdownTimeout is the default timeout for clean shutdown operations
+	defaultCleanShutdownTimeout = 30 * time.Second
 )
+
+// ShutdownMode specifies how the node should shutdown
+type ShutdownMode int
+
+const (
+	// ShutdownModeQuick keeps shard assignments and node registration for fast restart (default)
+	ShutdownModeQuick ShutdownMode = iota
+	// ShutdownModeClean releases shards and waits for handoff before unregistering
+	ShutdownModeClean
+)
+
+// String returns the string representation of the shutdown mode
+func (m ShutdownMode) String() string {
+	switch m {
+	case ShutdownModeQuick:
+		return "quick"
+	case ShutdownModeClean:
+		return "clean"
+	default:
+		return "unknown"
+	}
+}
 
 // ShardInfo contains information about a shard's node assignment
 type ShardInfo struct {
@@ -1782,4 +1806,155 @@ func (cm *ConsensusManager) GetObjectsToEvict(localAddr string, objectIDs []stri
 
 func (cm *ConsensusManager) GetClusterStateStabilityDurationForTesting() time.Duration {
 	return cm.clusterStateStabilityDuration
+}
+
+// Shutdown gracefully shuts down the consensus manager with the specified mode.
+// 
+// ShutdownModeQuick: Stop immediately, keeping shard assignments for fast restart
+// ShutdownModeClean: Release owned shards, wait for handoff, then allow normal shutdown
+//
+// For clean shutdown, this method will:
+// 1. Release all shards owned by this node (set CurrentNode to empty)
+// 2. Wait for other nodes to claim them (with timeout)  
+// 3. Return to allow normal unregistration to proceed
+//
+// The method respects context cancellation and has a built-in timeout for clean shutdowns.
+func (cm *ConsensusManager) Shutdown(ctx context.Context, mode ShutdownMode) error {
+	cm.logger.Infof("Starting shutdown in %s mode", mode)
+	
+	if mode == ShutdownModeQuick {
+		cm.logger.Infof("Quick shutdown: no shard release needed")
+		return nil
+	}
+	
+	if mode != ShutdownModeClean {
+		return fmt.Errorf("unsupported shutdown mode: %s", mode)
+	}
+	
+	// Clean shutdown: release shards and wait for handoff
+	return cm.performCleanShutdown(ctx)
+}
+
+// performCleanShutdown releases all shards owned by this node and waits for handoff
+func (cm *ConsensusManager) performCleanShutdown(ctx context.Context) error {
+	cm.mu.RLock()
+	localNode := cm.localNodeAddress
+	cm.mu.RUnlock()
+	
+	if localNode == "" {
+		return fmt.Errorf("local node address not set")
+	}
+	
+	// Add timeout to context if none exists
+	if _, hasDeadline := ctx.Deadline(); !hasDeadline {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, defaultCleanShutdownTimeout)
+		defer cancel()
+	}
+	
+	cm.logger.Infof("Clean shutdown: releasing shards owned by node %s", localNode)
+	
+	// Step 1: Identify and release shards owned by this node
+	shardsToRelease := cm.identifyOwnedShards(localNode)
+	if len(shardsToRelease) == 0 {
+		cm.logger.Infof("Clean shutdown: no shards to release")
+		return nil
+	}
+	
+	cm.logger.Infof("Clean shutdown: releasing %d shards", len(shardsToRelease))
+	
+	// Step 2: Release the shards (set CurrentNode to empty)
+	releasedCount, err := cm.storeShardMapping(ctx, shardsToRelease)
+	if err != nil {
+		cm.logger.Warnf("Clean shutdown: failed to release some shards: %d/%d released, error: %v", 
+			releasedCount, len(shardsToRelease), err)
+		// Continue with waiting for whatever we did release
+	} else {
+		cm.logger.Infof("Clean shutdown: successfully released %d shards", releasedCount)
+	}
+	
+	// Step 3: Wait for other nodes to claim the released shards
+	if releasedCount > 0 {
+		releasedShardIDs := make([]int, 0, len(shardsToRelease))
+		for shardID := range shardsToRelease {
+			releasedShardIDs = append(releasedShardIDs, shardID)
+		}
+		
+		err := cm.waitForShardHandoff(ctx, releasedShardIDs)
+		if err != nil {
+			cm.logger.Warnf("Clean shutdown: handoff wait completed with issues: %v", err)
+			// Don't fail shutdown due to handoff timeout - allow unregistration to proceed
+		} else {
+			cm.logger.Infof("Clean shutdown: all released shards have been claimed")
+		}
+	}
+	
+	cm.logger.Infof("Clean shutdown: shard release phase completed")
+	return nil
+}
+
+// identifyOwnedShards finds all shards where CurrentNode matches the local node
+func (cm *ConsensusManager) identifyOwnedShards(localNode string) map[int]ShardInfo {
+	cm.mu.RLock()
+	defer cm.mu.RUnlock()
+	
+	if cm.state.ShardMapping == nil {
+		return nil
+	}
+	
+	shardsToRelease := make(map[int]ShardInfo)
+	for shardID, shardInfo := range cm.state.ShardMapping.Shards {
+		if shardInfo.CurrentNode == localNode {
+			// Release this shard by setting CurrentNode to empty
+			// Keep TargetNode unchanged so leader can reassign appropriately
+			shardsToRelease[shardID] = shardInfo.WithCurrentNode("")
+		}
+	}
+	
+	return shardsToRelease
+}
+
+// waitForShardHandoff waits for other nodes to claim the released shards
+func (cm *ConsensusManager) waitForShardHandoff(ctx context.Context, releasedShardIDs []int) error {
+	cm.logger.Infof("Clean shutdown: waiting for %d shards to be claimed by other nodes", len(releasedShardIDs))
+	
+	ticker := time.NewTicker(1 * time.Second)
+	defer ticker.Stop()
+	
+	for {
+		select {
+		case <-ctx.Done():
+			unclaimed := cm.countUnclaimedShards(releasedShardIDs)
+			cm.logger.Warnf("Clean shutdown: handoff timeout - %d shards still unclaimed", unclaimed)
+			return fmt.Errorf("handoff timeout: %d shards still unclaimed", unclaimed)
+			
+		case <-ticker.C:
+			unclaimed := cm.countUnclaimedShards(releasedShardIDs)
+			if unclaimed == 0 {
+				cm.logger.Infof("Clean shutdown: all %d shards have been claimed", len(releasedShardIDs))
+				return nil
+			}
+			cm.logger.Debugf("Clean shutdown: %d shards still unclaimed", unclaimed)
+		}
+	}
+}
+
+// countUnclaimedShards returns the number of shards that are still unclaimed (CurrentNode is empty)
+func (cm *ConsensusManager) countUnclaimedShards(shardIDs []int) int {
+	cm.mu.RLock()
+	defer cm.mu.RUnlock()
+	
+	if cm.state.ShardMapping == nil {
+		return len(shardIDs)
+	}
+	
+	unclaimed := 0
+	for _, shardID := range shardIDs {
+		shardInfo, exists := cm.state.ShardMapping.Shards[shardID]
+		if !exists || shardInfo.CurrentNode == "" {
+			unclaimed++
+		}
+	}
+	
+	return unclaimed
 }

--- a/cluster/consensusmanager/consensusmanager_shutdown_test.go
+++ b/cluster/consensusmanager/consensusmanager_shutdown_test.go
@@ -1,0 +1,303 @@
+package consensusmanager
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/xiaonanln/goverse/cluster/etcdmanager"
+	"github.com/xiaonanln/goverse/cluster/shardlock"
+	"github.com/xiaonanln/goverse/util/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestShutdownMode_String(t *testing.T) {
+	tests := []struct {
+		mode     ShutdownMode
+		expected string
+	}{
+		{ShutdownModeQuick, "quick"},
+		{ShutdownModeClean, "clean"},
+		{ShutdownMode(999), "unknown"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.expected, func(t *testing.T) {
+			assert.Equal(t, tt.expected, tt.mode.String())
+		})
+	}
+}
+
+func TestConsensusManager_Shutdown_QuickMode(t *testing.T) {
+	etcdManager, cleanup := testutil.SetupTestEtcd(t)
+	defer cleanup()
+
+	numShards := 8
+	nodeAddr := "test-node:1234"
+	
+	cm := NewConsensusManager(etcdManager, shardlock.NewShardLock(), 
+		10*time.Second, nodeAddr, numShards)
+
+	ctx := context.Background()
+	err := cm.Initialize(ctx)
+	require.NoError(t, err)
+
+	// Test quick shutdown - should be immediate and not change anything
+	err = cm.Shutdown(ctx, ShutdownModeQuick)
+	assert.NoError(t, err)
+	
+	// Verify no changes to cluster state
+	state := cm.GetClusterStateForTesting()
+	assert.NotNil(t, state)
+}
+
+func TestConsensusManager_Shutdown_CleanMode_NoShards(t *testing.T) {
+	etcdManager, cleanup := testutil.SetupTestEtcd(t)
+	defer cleanup()
+
+	numShards := 8
+	nodeAddr := "test-node:1234"
+	
+	cm := NewConsensusManager(etcdManager, shardlock.NewShardLock(), 
+		10*time.Second, nodeAddr, numShards)
+
+	ctx := context.Background()
+	err := cm.Initialize(ctx)
+	require.NoError(t, err)
+
+	// Test clean shutdown with no owned shards
+	err = cm.Shutdown(ctx, ShutdownModeClean)
+	assert.NoError(t, err)
+}
+
+func TestConsensusManager_Shutdown_CleanMode_WithShards(t *testing.T) {
+	etcdManager, cleanup := testutil.SetupTestEtcd(t)
+	defer cleanup()
+
+	numShards := 8
+	nodeAddr := "test-node:1234"
+	otherNodeAddr := "other-node:5678"
+	
+	cm := NewConsensusManager(etcdManager, shardlock.NewShardLock(), 
+		10*time.Second, nodeAddr, numShards)
+
+	ctx := context.Background()
+	err := cm.Initialize(ctx)
+	require.NoError(t, err)
+
+	// Register this node and another node in etcd
+	err = cm.etcdManager.RegisterNode(ctx, nodeAddr)
+	require.NoError(t, err)
+	err = cm.etcdManager.RegisterNode(ctx, otherNodeAddr) 
+	require.NoError(t, err)
+	
+	// Set up initial shard mapping with some shards owned by this node
+	initialMapping := map[int]ShardInfo{
+		0: {TargetNode: nodeAddr, CurrentNode: nodeAddr},
+		1: {TargetNode: nodeAddr, CurrentNode: nodeAddr}, 
+		2: {TargetNode: otherNodeAddr, CurrentNode: otherNodeAddr},
+		3: {TargetNode: nodeAddr, CurrentNode: nodeAddr},
+	}
+	
+	_, err = cm.storeShardMapping(ctx, initialMapping)
+	require.NoError(t, err)
+	
+	// Wait for state to be updated
+	time.Sleep(100 * time.Millisecond)
+	
+	// Create a second consensus manager for the other node to claim released shards
+	otherCM := NewConsensusManager(etcdManager, shardlock.NewShardLock(), 
+		10*time.Second, otherNodeAddr, numShards)
+	err = otherCM.Initialize(ctx)
+	require.NoError(t, err)
+	
+	// Start watching for both managers to handle real-time updates
+	err = cm.StartWatch(ctx)
+	require.NoError(t, err)
+	defer cm.StopWatch()
+	
+	err = otherCM.StartWatch(ctx)
+	require.NoError(t, err) 
+	defer otherCM.StopWatch()
+	
+	// Start the other node claiming shards in the background
+	go func() {
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-time.After(50 * time.Millisecond):
+				// Try to claim shards for other node
+				otherCM.ClaimShardsForNode(ctx)
+			}
+		}
+	}()
+	
+	// Perform clean shutdown - this should release shards owned by nodeAddr
+	shutdownCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+	
+	err = cm.Shutdown(shutdownCtx, ShutdownModeClean)
+	assert.NoError(t, err)
+	
+	// Wait a moment for the state to propagate
+	time.Sleep(200 * time.Millisecond)
+	
+	// Verify that all shards that were owned by nodeAddr are now released or claimed by others
+	state := otherCM.GetClusterStateForTesting()
+	require.NotNil(t, state)
+	require.NotNil(t, state.ShardMapping)
+	
+	for shardID, shardInfo := range state.ShardMapping.Shards {
+		if shardID == 0 || shardID == 1 || shardID == 3 {
+			// These were owned by the shutting down node
+			assert.NotEqual(t, nodeAddr, shardInfo.CurrentNode, 
+				"Shard %d should not be owned by shutting down node %s", shardID, nodeAddr)
+		}
+	}
+}
+
+func TestConsensusManager_Shutdown_CleanMode_Timeout(t *testing.T) {
+	etcdManager, cleanup := testutil.SetupTestEtcd(t)
+	defer cleanup()
+
+	numShards := 4
+	nodeAddr := "test-node:1234"
+	
+	cm := NewConsensusManager(etcdManager, shardlock.NewShardLock(), 
+		10*time.Second, nodeAddr, numShards)
+
+	ctx := context.Background()
+	err := cm.Initialize(ctx)
+	require.NoError(t, err)
+
+	// Register this node
+	err = cm.etcdManager.RegisterNode(ctx, nodeAddr)
+	require.NoError(t, err)
+	
+	// Set up shards owned by this node
+	initialMapping := map[int]ShardInfo{
+		0: {TargetNode: nodeAddr, CurrentNode: nodeAddr},
+		1: {TargetNode: nodeAddr, CurrentNode: nodeAddr}, 
+	}
+	
+	_, err = cm.storeShardMapping(ctx, initialMapping)
+	require.NoError(t, err)
+	
+	// Create a very short timeout to test timeout behavior
+	shortCtx, cancel := context.WithTimeout(ctx, 100*time.Millisecond)
+	defer cancel()
+	
+	// Clean shutdown should timeout because no other nodes will claim the shards
+	err = cm.Shutdown(shortCtx, ShutdownModeClean)
+	// Should not fail even on timeout - it should continue with shutdown
+	assert.NoError(t, err)
+}
+
+func TestConsensusManager_Shutdown_UnsupportedMode(t *testing.T) {
+	etcdManager, cleanup := testutil.SetupTestEtcd(t)
+	defer cleanup()
+
+	numShards := 8
+	nodeAddr := "test-node:1234"
+	
+	cm := NewConsensusManager(etcdManager, shardlock.NewShardLock(), 
+		10*time.Second, nodeAddr, numShards)
+
+	ctx := context.Background()
+	err := cm.Initialize(ctx)
+	require.NoError(t, err)
+
+	// Test unsupported shutdown mode
+	err = cm.Shutdown(ctx, ShutdownMode(999))
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported shutdown mode")
+}
+
+func TestConsensusManager_identifyOwnedShards(t *testing.T) {
+	etcdManager, cleanup := testutil.SetupTestEtcd(t)
+	defer cleanup()
+
+	numShards := 8
+	nodeAddr := "test-node:1234"
+	otherNodeAddr := "other-node:5678"
+	
+	cm := NewConsensusManager(etcdManager, shardlock.NewShardLock(), 
+		10*time.Second, nodeAddr, numShards)
+
+	ctx := context.Background()
+	err := cm.Initialize(ctx)
+	require.NoError(t, err)
+
+	// Set up shard mapping 
+	cm.SetMappingForTesting(&ShardMapping{
+		Shards: map[int]ShardInfo{
+			0: {TargetNode: nodeAddr, CurrentNode: nodeAddr},      // Owned by this node
+			1: {TargetNode: otherNodeAddr, CurrentNode: nodeAddr}, // Owned by this node (migration)
+			2: {TargetNode: otherNodeAddr, CurrentNode: otherNodeAddr}, // Owned by other node
+			3: {TargetNode: nodeAddr, CurrentNode: ""},            // Not claimed yet
+		},
+	})
+	
+	// Test identifying owned shards
+	ownedShards := cm.identifyOwnedShards(nodeAddr)
+	
+	assert.Len(t, ownedShards, 2, "Should identify 2 owned shards")
+	
+	// Check shard 0 - owned by this node
+	assert.Contains(t, ownedShards, 0)
+	assert.Equal(t, nodeAddr, ownedShards[0].TargetNode)
+	assert.Equal(t, "", ownedShards[0].CurrentNode) // Should be set to empty for release
+	
+	// Check shard 1 - owned by this node but migrating
+	assert.Contains(t, ownedShards, 1)
+	assert.Equal(t, otherNodeAddr, ownedShards[1].TargetNode) // Should preserve TargetNode
+	assert.Equal(t, "", ownedShards[1].CurrentNode)          // Should be set to empty for release
+	
+	// Should not contain shard 2 (owned by other node) or shard 3 (not claimed)
+	assert.NotContains(t, ownedShards, 2)
+	assert.NotContains(t, ownedShards, 3)
+}
+
+func TestConsensusManager_countUnclaimedShards(t *testing.T) {
+	etcdManager, cleanup := testutil.SetupTestEtcd(t)
+	defer cleanup()
+
+	numShards := 8
+	nodeAddr := "test-node:1234"
+	otherNodeAddr := "other-node:5678"
+	
+	cm := NewConsensusManager(etcdManager, shardlock.NewShardLock(), 
+		10*time.Second, nodeAddr, numShards)
+
+	ctx := context.Background()
+	err := cm.Initialize(ctx)
+	require.NoError(t, err)
+
+	// Set up shard mapping
+	cm.SetMappingForTesting(&ShardMapping{
+		Shards: map[int]ShardInfo{
+			0: {TargetNode: nodeAddr, CurrentNode: otherNodeAddr}, // Claimed by other node
+			1: {TargetNode: nodeAddr, CurrentNode: ""},            // Unclaimed
+			2: {TargetNode: nodeAddr, CurrentNode: ""},            // Unclaimed
+			3: {TargetNode: otherNodeAddr, CurrentNode: otherNodeAddr}, // Claimed by other node
+		},
+	})
+	
+	// Test counting unclaimed shards
+	shardIDs := []int{0, 1, 2, 3}
+	unclaimed := cm.countUnclaimedShards(shardIDs)
+	
+	assert.Equal(t, 2, unclaimed, "Should have 2 unclaimed shards (1 and 2)")
+	
+	// Test with empty shard mapping
+	cm.SetMappingForTesting(&ShardMapping{Shards: map[int]ShardInfo{}})
+	unclaimed = cm.countUnclaimedShards(shardIDs)
+	assert.Equal(t, 4, unclaimed, "All shards should be unclaimed with empty mapping")
+	
+	// Test with nil shard mapping
+	cm.SetMappingForTesting(nil)
+	unclaimed = cm.countUnclaimedShards(shardIDs)
+	assert.Equal(t, 4, unclaimed, "All shards should be unclaimed with nil mapping")
+}

--- a/docs/GRACEFUL_SHUTDOWN_DESIGN.md
+++ b/docs/GRACEFUL_SHUTDOWN_DESIGN.md
@@ -1,0 +1,252 @@
+# Graceful Shutdown Mode Design
+
+## Problem Statement
+
+Currently, GoVerse nodes have only one shutdown behavior: they immediately stop, keeping their shard assignments and node registration in etcd. This works well for rolling updates where the node will restart and reclaim its shards, but it's suboptimal for scale-down operations where the node won't return.
+
+For scale-down, keeping shard assignments in etcd means:
+1. Other nodes can't immediately take over the shards
+2. The leader must detect the node failure and reassign shards
+3. Recovery time is longer than necessary
+
+We need two distinct shutdown modes:
+1. **Quick shutdown** (current behavior): Keep assignments for fast restart
+2. **Clean shutdown**: Proactively release shards for faster cluster recovery
+
+## Shutdown Modes
+
+### Quick Shutdown (Default)
+- **Use case**: Rolling updates, node restarts, maintenance
+- **Behavior**: Stop immediately, keep shard assignments and node registration in etcd
+- **Recovery**: Node can reclaim its shards quickly on restart
+- **Trade-off**: Temporary unavailability until leader reassigns dead node's shards
+
+### Clean Shutdown (Graceful)
+- **Use case**: Scale-down, permanent node removal
+- **Behavior**: Release all owned shards → wait for handoff → unregister node → exit
+- **Recovery**: Other nodes can immediately claim released shards
+- **Trade-off**: Slower shutdown process, but faster cluster recovery
+
+## API Design
+
+### ShutdownMode Type
+```go
+package consensusmanager
+
+type ShutdownMode int
+
+const (
+    ShutdownModeQuick ShutdownMode = iota
+    ShutdownModeClean
+)
+
+func (m ShutdownMode) String() string {
+    switch m {
+    case ShutdownModeQuick:
+        return "quick"
+    case ShutdownModeClean:
+        return "clean"  
+    default:
+        return "unknown"
+    }
+}
+```
+
+### ConsensusManager API
+```go
+// Shutdown gracefully shuts down the consensus manager with the specified mode
+func (cm *ConsensusManager) Shutdown(ctx context.Context, mode ShutdownMode) error
+```
+
+### Integration Points
+- `cluster.Cluster.Stop()` will accept a mode parameter
+- `server.Server.Run()` signal handler will use ShutdownModeQuick by default
+- Environment variable `GOVERSE_SHUTDOWN_MODE=clean` can override the default
+- Future: CLI flag `--shutdown-mode=clean` for explicit control
+
+## Implementation Plan
+
+### Phase 1: Core Infrastructure (This PR)
+**Goal**: Add shutdown mode support without changing existing signal handling
+
+**Changes**:
+1. **Add ShutdownMode type** in `cluster/consensusmanager/consensusmanager.go`
+2. **Add Shutdown method** to ConsensusManager:
+   ```go
+   func (cm *ConsensusManager) Shutdown(ctx context.Context, mode ShutdownMode) error
+   ```
+3. **Implement clean shutdown logic**:
+   - Release all shards owned by this node (set CurrentNode to empty)
+   - Wait for other nodes to claim them (with timeout)
+   - Only then allow normal unregistration to proceed
+4. **Add comprehensive tests** for shutdown modes
+5. **Update cluster.Stop()** to accept shutdown mode parameter
+
+**NOT in scope for this PR**:
+- Signal handling changes (still uses current behavior)
+- CLI flags or environment variables 
+- Gate server shutdown changes
+
+### Phase 2: Signal Integration (Follow-up PR)
+- Environment variable support for `GOVERSE_SHUTDOWN_MODE`
+- Signal handling changes in `server/server.go`
+- CLI flag support in server config
+- Gate server shutdown mode support
+
+### Phase 3: Advanced Features (Future PRs)  
+- Timeout configuration for shard release
+- Metrics for shutdown operations
+- Kubernetes integration guidance
+
+## Sequence Diagrams
+
+### Current Shutdown (Quick Mode)
+```
+Node                ConsensusManager         etcd                Other Nodes
+ |                        |                   |                      |
+ | SIGTERM               |                   |                      |
+ |-----> Stop()           |                   |                      |
+ |       |                |                   |                      |
+ |       |---> StopWatch() |                   |                      |
+ |       |---> unregister  |                   |                      |
+ |       |                |---> DELETE /nodes/addr                   |
+ |       |                |                   |                      |
+ | Exit  |                |                   |                      |
+ |                        |                   |                      |
+ |                        |                   |                      |
+ |                        |                   | Leader detects        |
+ |                        |                   | dead node and         |
+ |                        |                   | reassigns shards      |
+ |                        |                   |<--------------------- |
+```
+
+### Proposed Clean Shutdown
+```
+Node                ConsensusManager         etcd                Other Nodes  
+ |                        |                   |                      |
+ | SIGTERM               |                   |                      |
+ |-----> Stop(Clean)      |                   |                      |
+ |       |                |                   |                      |
+ |       |---> Shutdown(Clean)                |                      |
+ |       |                |                   |                      |
+ |       |                | Release shards    |                      |
+ |       |                |---> PUT /shard/N (CurrentNode="")        |
+ |       |                |                   |---> Watch event ---->|
+ |       |                |                   |                      |
+ |       |                | Wait for claim    |                      |
+ |       |                |<--- GET /shard/N <----|<--- Claim shard  |
+ |       |                |                   |<--- PUT /shard/N ----|
+ |       |                |                   |                      |
+ |       |---> StopWatch() |                   |                      |
+ |       |---> unregister  |                   |                      |
+ |       |                |---> DELETE /nodes/addr                   |
+ | Exit  |                |                   |                      |
+```
+
+## Error Handling
+
+### Timeout Scenarios
+- **Shard release timeout**: If other nodes don't claim released shards within timeout, proceed with unregistration anyway
+- **Context cancellation**: If shutdown context is cancelled, immediately proceed to unregistration
+- **etcd errors**: Log errors but continue with shutdown process
+
+### Partial Failures
+- **Some shards fail to release**: Log errors, continue with remaining shards
+- **Some shards not claimed**: After timeout, proceed with unregistration
+- **Network partition**: Shutdown should complete locally even if etcd is unreachable
+
+## Configuration
+
+### Default Behavior
+- Current behavior unchanged: Quick shutdown by default
+- No breaking changes to existing APIs
+
+### Environment Variables (Phase 2)
+```bash
+# Override default shutdown mode
+GOVERSE_SHUTDOWN_MODE=clean
+
+# Timeout for clean shutdown shard release
+GOVERSE_CLEAN_SHUTDOWN_TIMEOUT=30s
+```
+
+### Config File Support (Phase 2)
+```yaml
+cluster:
+  shutdown_mode: clean
+  clean_shutdown_timeout: 30s
+```
+
+## Testing Strategy
+
+### Unit Tests
+- `TestConsensusManager_Shutdown_QuickMode`
+- `TestConsensusManager_Shutdown_CleanMode`
+- `TestConsensusManager_Shutdown_Timeout`
+- `TestConsensusManager_Shutdown_PartialFailure`
+
+### Integration Tests
+- Multi-node cluster with real etcd
+- Verify shard migration during clean shutdown
+- Verify other nodes claim released shards
+- Verify timeout behavior
+
+### Error Injection Tests
+- etcd unavailable during shutdown
+- Context cancellation during shutdown
+- Network partitions during shutdown
+
+## Metrics and Observability
+
+### Metrics (Future Enhancement)
+```
+goverse_shutdown_total{mode="clean|quick", status="success|timeout|error"}
+goverse_shutdown_duration_seconds{mode="clean|quick"}  
+goverse_shards_released_total{node}
+goverse_clean_shutdown_timeouts_total
+```
+
+### Logging
+- INFO: Shutdown mode selection
+- INFO: Shard release progress 
+- WARN: Shard release timeouts
+- ERROR: Shutdown failures
+
+## Migration and Compatibility
+
+### Backward Compatibility
+- Existing `cluster.Stop()` calls use Quick mode (no behavior change)
+- No changes to public APIs in Phase 1
+- All existing tests pass unchanged
+
+### Migration Path
+1. Deploy Phase 1 changes (infrastructure only)
+2. Test clean shutdown manually via API
+3. Deploy Phase 2 (environment variable support)
+4. Gradually enable clean shutdown for scale-down scenarios
+5. Add to Kubernetes deployment guides
+
+## Future Enhancements
+
+### Advanced Shutdown Coordination
+- Graceful connection draining before shard release
+- Coordinated shutdown for batch operations
+- Rolling shutdown with min-replicas enforcement
+
+### Kubernetes Integration
+- Pod deletion hooks to trigger clean shutdown
+- PreStop lifecycle hooks
+- Shutdown mode detection via Kubernetes annotations
+
+### Multi-Shard Atomic Release
+- Release shards in batches for faster handoff
+- Priority-based shard release ordering
+- Load-aware shard assignment during shutdown
+
+## References
+
+- SHARDING_TODO.md P1: "Add optional shard release for permanent shutdown"
+- MILESTONE_V0.1.0.md: "Graceful Shutdown Mode (P1)"
+- cluster/consensusmanager/consensusmanager.go: Shard management logic
+- server/server.go: Current signal handling
+- cluster/cluster.go: Current Stop() implementation


### PR DESCRIPTION
## What

Add shutdown mode infrastructure for goverse nodes:

- **Quick mode** (default): Current behavior — stop immediately, keep shard assignments in etcd for fast reclaim on restart. Use for rolling updates.
- **Clean mode**: Release all owned shards → wait for other nodes to claim them → unregister node. Use for scale-down.

## Changes

- Add `ShutdownMode` type (`Quick`/`Clean`) to consensusmanager
- Add `Shutdown(ctx, mode)` method with clean shutdown shard release logic
- Add `cluster.StopWithMode()` for explicit mode control
- Existing `cluster.Stop()` unchanged (uses Quick mode, backward compatible)
- Design doc: `docs/GRACEFUL_SHUTDOWN_DESIGN.md`

## Tests

- Unit tests for shutdown mode logic
- Integration tests with etcd
- Error handling, timeouts, partial failure scenarios

Ref: MILESTONE_V0.1.0.md item #2, SHARDING_TODO.md P1