### PR TITLE
Make Call/Create/Delete timeouts configurable and emit metrics

### DIFF
--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -18,6 +18,7 @@ import (
 	goverse_pb "github.com/xiaonanln/goverse/proto"
 	"github.com/xiaonanln/goverse/util/backoff"
 	"github.com/xiaonanln/goverse/util/callcontext"
+	uerrors "github.com/xiaonanln/goverse/util/errors"
 	"github.com/xiaonanln/goverse/util/logger"
 	"github.com/xiaonanln/goverse/util/metrics"
 	"github.com/xiaonanln/goverse/util/protohelper"
@@ -51,6 +52,22 @@ func effectiveTimeout(configured, fallback time.Duration) time.Duration {
 		return configured
 	}
 	return fallback
+}
+
+// recordOperationResult emits duration + timeout metrics for a cluster operation.
+// Intended to be called from a deferred function with the initial start time and
+// the final (named) error return value.
+func recordOperationResult(addr, operation string, start time.Time, err error) {
+	status := "success"
+	if err != nil {
+		if uerrors.IsTimeout(err) {
+			metrics.RecordOperationTimeout(addr, operation)
+			status = "timeout"
+		} else {
+			status = "error"
+		}
+	}
+	metrics.RecordOperationDuration(addr, operation, status, time.Since(start).Seconds())
 }
 
 type Cluster struct {
@@ -534,7 +551,10 @@ func (c *Cluster) checkAndMarkReady() {
 	c.markClusterReady()
 }
 
-func (c *Cluster) CallObject(ctx context.Context, objType string, id string, method string, request proto.Message) (proto.Message, error) {
+func (c *Cluster) CallObject(ctx context.Context, objType string, id string, method string, request proto.Message) (result proto.Message, err error) {
+	start := time.Now()
+	defer func() { recordOperationResult(c.getAdvertiseAddr(), "CallObject", start, err) }()
+
 	// Enforce default call timeout. context.WithTimeout uses the sooner of
 	// the existing deadline and the new timeout, so this is always safe.
 	ctx, cancel := context.WithTimeout(ctx, effectiveTimeout(c.config.DefaultCallTimeout, DefaultCallTimeout))
@@ -601,10 +621,13 @@ func (c *Cluster) CallObject(ctx context.Context, objType string, id string, met
 // CallObjectAnyRequest calls a method on a distributed object, accepting an *anypb.Any request.
 // This is an optimized version that avoids unnecessary marshal/unmarshal cycles when the request
 // is already in Any format (e.g., from a gate that received it from a client).
-func (c *Cluster) CallObjectAnyRequest(ctx context.Context, objType string, id string, method string, request *anypb.Any) (*anypb.Any, error) {
+func (c *Cluster) CallObjectAnyRequest(ctx context.Context, objType string, id string, method string, request *anypb.Any) (result *anypb.Any, err error) {
 	if !c.isGate() {
 		return nil, fmt.Errorf("CallObjectAnyRequest can only be called on gate clusters")
 	}
+
+	start := time.Now()
+	defer func() { recordOperationResult(c.getAdvertiseAddr(), "CallObject", start, err) }()
 
 	// Enforce default call timeout
 	ctx, cancel := context.WithTimeout(ctx, effectiveTimeout(c.config.DefaultCallTimeout, DefaultCallTimeout))
@@ -648,7 +671,10 @@ func (c *Cluster) CallObjectAnyRequest(ctx context.Context, objType string, id s
 // CreateObject creates a distributed object on the appropriate node based on sharding
 // The object ID is determined by the type and optional custom ID
 // This method routes the creation request to the correct node in the cluster
-func (c *Cluster) CreateObject(ctx context.Context, objType, objID string) (string, error) {
+func (c *Cluster) CreateObject(ctx context.Context, objType, objID string) (resultID string, err error) {
+	start := time.Now()
+	defer func() { recordOperationResult(c.getAdvertiseAddr(), "CreateObject", start, err) }()
+
 	// Enforce default create timeout for synchronous operations in this function.
 	// Async goroutines create their own timeout context because this one is
 	// cancelled by defer when the function returns.
@@ -737,7 +763,10 @@ func (c *Cluster) CreateObject(ctx context.Context, objType, objID string) (stri
 // It determines which node hosts the object and routes the deletion request accordingly.
 // For gates, the deletion is performed synchronously. For nodes, it is performed
 // asynchronously to prevent deadlocks when called from within object methods.
-func (c *Cluster) DeleteObject(ctx context.Context, objID string) error {
+func (c *Cluster) DeleteObject(ctx context.Context, objID string) (err error) {
+	start := time.Now()
+	defer func() { recordOperationResult(c.getAdvertiseAddr(), "DeleteObject", start, err) }()
+
 	// Enforce default delete timeout for synchronous operations in this function.
 	// Async goroutines create their own timeout context because this one is
 	// cancelled by defer when the function returns.

--- a/cluster/cluster_operation_metrics_test.go
+++ b/cluster/cluster_operation_metrics_test.go
@@ -1,0 +1,50 @@
+package cluster
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	uerrors "github.com/xiaonanln/goverse/util/errors"
+	"github.com/xiaonanln/goverse/util/metrics"
+)
+
+// TestRecordOperationResult verifies that the timeout counter is emitted only
+// for timeout errors and that the operation runs for each outcome without
+// panicking. Duration histogram semantics are covered by util/metrics tests.
+func TestRecordOperationResult(t *testing.T) {
+	const operation = "TestOp"
+	// Unique address per run so the counter series is isolated from other tests.
+	addr := fmt.Sprintf("recordop-%d", time.Now().UnixNano())
+
+	timeouts := func() float64 {
+		return testutil.ToFloat64(metrics.OperationTimeoutsTotal.WithLabelValues(addr, operation))
+	}
+
+	// Success: no timeout counter.
+	recordOperationResult(addr, operation, time.Now(), nil)
+	if got := timeouts(); got != 0 {
+		t.Fatalf("success: timeout counter = %v, want 0", got)
+	}
+
+	// Non-timeout error: no timeout counter.
+	recordOperationResult(addr, operation, time.Now(), fmt.Errorf("boom"))
+	if got := timeouts(); got != 0 {
+		t.Fatalf("error: timeout counter = %v, want 0", got)
+	}
+
+	// TimeoutError: counter increments.
+	recordOperationResult(addr, operation, time.Now(),
+		uerrors.NewTimeoutError(operation, "obj-1", context.DeadlineExceeded))
+	if got := timeouts(); got != 1 {
+		t.Fatalf("TimeoutError: timeout counter = %v, want 1", got)
+	}
+
+	// Raw context.DeadlineExceeded is also classified as a timeout.
+	recordOperationResult(addr, operation, time.Now(), context.DeadlineExceeded)
+	if got := timeouts(); got != 2 {
+		t.Fatalf("DeadlineExceeded: timeout counter = %v, want 2", got)
+	}
+}

--- a/config/config.go
+++ b/config/config.go
@@ -10,12 +10,21 @@ import (
 
 // ClusterConfig holds cluster-level configuration
 type ClusterConfig struct {
-	Shards                        int                    `yaml:"shards"`
-	Provider                      string                 `yaml:"provider"`
-	Etcd                          EtcdConfig             `yaml:"etcd"`
-	ImbalanceThreshold            float64                `yaml:"imbalance_threshold,omitempty"`
-	ClusterStateStabilityDuration time.Duration          `yaml:"cluster_state_stability_duration,omitempty"`
-	AutoLoadObjects               []AutoLoadObjectConfig `yaml:"auto_load_objects,omitempty"`
+	Shards                        int           `yaml:"shards"`
+	Provider                      string        `yaml:"provider"`
+	Etcd                          EtcdConfig    `yaml:"etcd"`
+	ImbalanceThreshold            float64       `yaml:"imbalance_threshold,omitempty"`
+	ClusterStateStabilityDuration time.Duration `yaml:"cluster_state_stability_duration,omitempty"`
+	// DefaultCallTimeout is the default timeout applied to CallObject when the
+	// caller context has no deadline. Zero means use the built-in default.
+	DefaultCallTimeout time.Duration `yaml:"default_call_timeout,omitempty"`
+	// DefaultCreateTimeout is the default timeout applied to CreateObject when the
+	// caller context has no deadline. Zero means use the built-in default.
+	DefaultCreateTimeout time.Duration `yaml:"default_create_timeout,omitempty"`
+	// DefaultDeleteTimeout is the default timeout applied to DeleteObject when the
+	// caller context has no deadline. Zero means use the built-in default.
+	DefaultDeleteTimeout time.Duration          `yaml:"default_delete_timeout,omitempty"`
+	AutoLoadObjects      []AutoLoadObjectConfig `yaml:"auto_load_objects,omitempty"`
 }
 
 // AutoLoadObjectConfig specifies an object to auto-load when a node starts
@@ -216,6 +225,24 @@ func (c *Config) GetNumShards() int {
 // Returns 0 if not configured (caller should use default).
 func (c *Config) GetClusterStateStabilityDuration() time.Duration {
 	return c.Cluster.ClusterStateStabilityDuration
+}
+
+// GetDefaultCallTimeout returns the configured default CallObject timeout.
+// Returns 0 if not configured (caller should use default).
+func (c *Config) GetDefaultCallTimeout() time.Duration {
+	return c.Cluster.DefaultCallTimeout
+}
+
+// GetDefaultCreateTimeout returns the configured default CreateObject timeout.
+// Returns 0 if not configured (caller should use default).
+func (c *Config) GetDefaultCreateTimeout() time.Duration {
+	return c.Cluster.DefaultCreateTimeout
+}
+
+// GetDefaultDeleteTimeout returns the configured default DeleteObject timeout.
+// Returns 0 if not configured (caller should use default).
+func (c *Config) GetDefaultDeleteTimeout() time.Duration {
+	return c.Cluster.DefaultDeleteTimeout
 }
 
 // GetInspectorAdvertiseAddress returns the inspector advertise address.

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -730,6 +730,87 @@ nodes:
 	}
 }
 
+func TestDefaultOperationTimeouts(t *testing.T) {
+	configContent := `
+version: 1
+
+cluster:
+  shards: 8192
+  provider: "etcd"
+  etcd:
+    endpoints:
+      - "127.0.0.1:2379"
+    prefix: "/goverse"
+  default_call_timeout: 45s
+  default_create_timeout: 12s
+  default_delete_timeout: 7s
+
+nodes:
+  - id: "node-1"
+    grpc_addr: "0.0.0.0:9101"
+    advertise_addr: "node-1.local:9101"
+`
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "config.yml")
+	if err := os.WriteFile(configPath, []byte(configContent), 0600); err != nil {
+		t.Fatalf("failed to write config file: %v", err)
+	}
+
+	cfg, err := LoadConfig(configPath)
+	if err != nil {
+		t.Fatalf("LoadConfig failed: %v", err)
+	}
+
+	if got := cfg.GetDefaultCallTimeout(); got != 45*time.Second {
+		t.Fatalf("GetDefaultCallTimeout() = %v, want 45s", got)
+	}
+	if got := cfg.GetDefaultCreateTimeout(); got != 12*time.Second {
+		t.Fatalf("GetDefaultCreateTimeout() = %v, want 12s", got)
+	}
+	if got := cfg.GetDefaultDeleteTimeout(); got != 7*time.Second {
+		t.Fatalf("GetDefaultDeleteTimeout() = %v, want 7s", got)
+	}
+}
+
+func TestDefaultOperationTimeoutsOptional(t *testing.T) {
+	configContent := `
+version: 1
+
+cluster:
+  shards: 8192
+  provider: "etcd"
+  etcd:
+    endpoints:
+      - "127.0.0.1:2379"
+    prefix: "/goverse"
+
+nodes:
+  - id: "node-1"
+    grpc_addr: "0.0.0.0:9101"
+    advertise_addr: "node-1.local:9101"
+`
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "config.yml")
+	if err := os.WriteFile(configPath, []byte(configContent), 0600); err != nil {
+		t.Fatalf("failed to write config file: %v", err)
+	}
+
+	cfg, err := LoadConfig(configPath)
+	if err != nil {
+		t.Fatalf("LoadConfig failed: %v", err)
+	}
+
+	if got := cfg.GetDefaultCallTimeout(); got != 0 {
+		t.Fatalf("GetDefaultCallTimeout() = %v, want 0", got)
+	}
+	if got := cfg.GetDefaultCreateTimeout(); got != 0 {
+		t.Fatalf("GetDefaultCreateTimeout() = %v, want 0", got)
+	}
+	if got := cfg.GetDefaultDeleteTimeout(); got != 0 {
+		t.Fatalf("GetDefaultDeleteTimeout() = %v, want 0", got)
+	}
+}
+
 func TestGetInspectorAdvertiseAddress(t *testing.T) {
 	tests := []struct {
 		name         string

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -93,6 +93,9 @@ Cluster-level configuration for distributed coordination.
 | `provider` | string | Yes | - | Cluster coordination provider. Currently only `"etcd"` is supported. |
 | `etcd` | object | Yes | - | etcd-specific configuration. |
 | `cluster_state_stability_duration` | duration | No | `10s` | How long the node list must be stable before updating shard mapping. |
+| `default_call_timeout` | duration | No | `30s` | Default timeout applied to `CallObject` when the caller context has no deadline. |
+| `default_create_timeout` | duration | No | `30s` | Default timeout applied to `CreateObject` when the caller context has no deadline. |
+| `default_delete_timeout` | duration | No | `30s` | Default timeout applied to `DeleteObject` when the caller context has no deadline. |
 | `auto_load_objects` | array | No | `[]` | List of objects to automatically load when a node starts. See [cluster.auto_load_objects](#clusterauto_load_objects). |
 
 #### cluster.etcd

--- a/node/serverconfig/serverconfig.go
+++ b/node/serverconfig/serverconfig.go
@@ -114,6 +114,9 @@ func (l *Loader) Load(args []string) (*server.ServerConfig, error) {
 			NodeStabilityDuration: cfg.GetClusterStateStabilityDuration(),
 			InspectorAddress:      cfg.GetInspectorAdvertiseAddress(),
 			AutoLoadObjects:       cfg.GetAutoLoadObjects(),
+			DefaultCallTimeout:    cfg.GetDefaultCallTimeout(),
+			DefaultCreateTimeout:  cfg.GetDefaultCreateTimeout(),
+			DefaultDeleteTimeout:  cfg.GetDefaultDeleteTimeout(),
 			ConfigFile:            cfg, // Pass the loaded config file
 		}, nil
 	}

--- a/server/server.go
+++ b/server/server.go
@@ -43,7 +43,11 @@ type ServerConfig struct {
 	AccessValidator           *config.AccessValidator       // Optional: access validator for node access control
 	LifecycleValidator        *config.LifecycleValidator    // Optional: lifecycle validator for CREATE/DELETE control
 	AutoLoadObjects           []config.AutoLoadObjectConfig // Optional: objects to auto-load when node starts and claims shards
-	ConfigFile                *config.Config                // Optional: loaded config file (if config file was used)
+	// Default timeouts applied when caller context has no deadline. Zero means use built-in defaults.
+	DefaultCallTimeout   time.Duration
+	DefaultCreateTimeout time.Duration
+	DefaultDeleteTimeout time.Duration
+	ConfigFile           *config.Config // Optional: loaded config file (if config file was used)
 }
 
 type Server struct {
@@ -101,6 +105,15 @@ func NewServer(config *ServerConfig) (*Server, error) {
 	}
 	if len(config.AutoLoadObjects) > 0 {
 		clusterCfg.AutoLoadObjects = config.AutoLoadObjects
+	}
+	if config.DefaultCallTimeout > 0 {
+		clusterCfg.DefaultCallTimeout = config.DefaultCallTimeout
+	}
+	if config.DefaultCreateTimeout > 0 {
+		clusterCfg.DefaultCreateTimeout = config.DefaultCreateTimeout
+	}
+	if config.DefaultDeleteTimeout > 0 {
+		clusterCfg.DefaultDeleteTimeout = config.DefaultDeleteTimeout
 	}
 	if config.ConfigFile != nil {
 		clusterCfg.ConfigFile = config.ConfigFile


### PR DESCRIPTION
## Summary

Part of the v0.1.0 "Default Timeout Enforcement" milestone. `CallObject`, `CreateObject`, and `DeleteObject` already enforced a default timeout via `effectiveTimeout`, but:
- the timeout values were hardcoded with no way to override via config
- the `goverse_operation_timeouts_total` / `goverse_operation_duration_seconds` metrics defined in `util/metrics` were never emitted

This PR closes both gaps without touching the enforcement logic.

### Changes
- `config.ClusterConfig` gains `default_call_timeout`, `default_create_timeout`, `default_delete_timeout` YAML fields plus matching `Config` getters.
- `server.ServerConfig` gains `DefaultCallTimeout` / `DefaultCreateTimeout` / `DefaultDeleteTimeout`; `node/serverconfig` populates them from YAML and `server.NewServer` applies them to `cluster.Config` (zero preserves the built-in default).
- `cluster.Cluster.CallObject`, `CallObjectAnyRequest`, `CreateObject`, `DeleteObject` now defer-emit `goverse_operation_timeouts_total` + `goverse_operation_duration_seconds`, classifying the outcome as `success` / `error` / `timeout` via `uerrors.IsTimeout`.
- New unit tests for YAML loading and `recordOperationResult` outcome classification.
- `docs/CONFIGURATION.md` updated with the three new fields.

### Intentionally out of scope
`EtcdOperationTimeout` / `ConnectionTimeout` plumbing (also listed in TIMEOUT_DESIGN.md) — they would require changing the signature of `NewEtcdManager` across 70+ call sites and reworking the connection pool. Current hardcoded defaults (60s etcd, 30s gRPC dial) already prevent hangs. I'll file a follow-up.

## Test plan
- [x] `go build ./...` and `go vet ./...` clean
- [x] `go test -count=1 ./cluster` (129s, all pass)
- [x] `go test ./config ./server ./node/serverconfig` pass
- [x] New `TestDefaultOperationTimeouts` + `TestDefaultOperationTimeoutsOptional` verify YAML round-trip
- [x] New `TestRecordOperationResult` covers success / error / timeout / raw `context.DeadlineExceeded`

🤖 Generated with [Claude Code](https://claude.com/claude-code)