### PR TITLE
Make default Call/Create/Delete timeouts configurable via YAML

### DIFF
--- a/cmd/gate/gateconfig/gateconfig.go
+++ b/cmd/gate/gateconfig/gateconfig.go
@@ -118,6 +118,9 @@ func (l *Loader) Load(args []string) (*gateserver.GateServerConfig, error) {
 			NumShards:                     cfg.GetNumShards(),
 			ClusterStateStabilityDuration: cfg.GetClusterStateStabilityDuration(),
 			InspectorAddress:              cfg.GetInspectorAdvertiseAddress(),
+			DefaultCallTimeout:            cfg.GetDefaultCallTimeout(),
+			DefaultCreateTimeout:          cfg.GetDefaultCreateTimeout(),
+			DefaultDeleteTimeout:          cfg.GetDefaultDeleteTimeout(),
 			ConfigFile:                    cfg, // Pass the loaded config file
 		}, nil
 	}

--- a/cmd/gate/gateconfig/gateconfig_test.go
+++ b/cmd/gate/gateconfig/gateconfig_test.go
@@ -460,6 +460,51 @@ gates:
 	}
 }
 
+func TestLoaderWithDefaultOperationTimeouts(t *testing.T) {
+	configContent := `
+version: 1
+
+cluster:
+  shards: 4096
+  provider: "etcd"
+  etcd:
+    endpoints:
+      - "etcd-cluster:2379"
+    prefix: "/goverse-test"
+  default_call_timeout: 45s
+  default_create_timeout: 12s
+  default_delete_timeout: 7s
+
+gates:
+  - id: "gate-1"
+    grpc_addr: "0.0.0.0:10001"
+    advertise_addr: "gate-1.local:10001"
+`
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "config.yaml")
+	if err := os.WriteFile(configPath, []byte(configContent), 0600); err != nil {
+		t.Fatalf("failed to write config file: %v", err)
+	}
+
+	fs := flag.NewFlagSet("test", flag.ContinueOnError)
+	loader := NewLoader(fs)
+
+	cfg, err := loader.Load([]string{"-config", configPath, "-gate-id", "gate-1"})
+	if err != nil {
+		t.Fatalf("Load failed: %v", err)
+	}
+
+	if cfg.DefaultCallTimeout != 45*time.Second {
+		t.Errorf("expected DefaultCallTimeout 45s, got %v", cfg.DefaultCallTimeout)
+	}
+	if cfg.DefaultCreateTimeout != 12*time.Second {
+		t.Errorf("expected DefaultCreateTimeout 12s, got %v", cfg.DefaultCreateTimeout)
+	}
+	if cfg.DefaultDeleteTimeout != 7*time.Second {
+		t.Errorf("expected DefaultDeleteTimeout 7s, got %v", cfg.DefaultDeleteTimeout)
+	}
+}
+
 func TestLoaderWithoutClusterStateStabilityDuration(t *testing.T) {
 	// Create a temp config file without cluster_state_stability_duration
 	configContent := `

--- a/config/config.go
+++ b/config/config.go
@@ -10,12 +10,21 @@ import (
 
 // ClusterConfig holds cluster-level configuration
 type ClusterConfig struct {
-	Shards                        int                    `yaml:"shards"`
-	Provider                      string                 `yaml:"provider"`
-	Etcd                          EtcdConfig             `yaml:"etcd"`
-	ImbalanceThreshold            float64                `yaml:"imbalance_threshold,omitempty"`
-	ClusterStateStabilityDuration time.Duration          `yaml:"cluster_state_stability_duration,omitempty"`
-	AutoLoadObjects               []AutoLoadObjectConfig `yaml:"auto_load_objects,omitempty"`
+	Shards                        int           `yaml:"shards"`
+	Provider                      string        `yaml:"provider"`
+	Etcd                          EtcdConfig    `yaml:"etcd"`
+	ImbalanceThreshold            float64       `yaml:"imbalance_threshold,omitempty"`
+	ClusterStateStabilityDuration time.Duration `yaml:"cluster_state_stability_duration,omitempty"`
+	// DefaultCallTimeout is the default timeout applied to CallObject when the
+	// caller context has no deadline. Zero means use the built-in default.
+	DefaultCallTimeout time.Duration `yaml:"default_call_timeout,omitempty"`
+	// DefaultCreateTimeout is the default timeout applied to CreateObject when the
+	// caller context has no deadline. Zero means use the built-in default.
+	DefaultCreateTimeout time.Duration `yaml:"default_create_timeout,omitempty"`
+	// DefaultDeleteTimeout is the default timeout applied to DeleteObject when the
+	// caller context has no deadline. Zero means use the built-in default.
+	DefaultDeleteTimeout time.Duration          `yaml:"default_delete_timeout,omitempty"`
+	AutoLoadObjects      []AutoLoadObjectConfig `yaml:"auto_load_objects,omitempty"`
 }
 
 // AutoLoadObjectConfig specifies an object to auto-load when a node starts
@@ -216,6 +225,24 @@ func (c *Config) GetNumShards() int {
 // Returns 0 if not configured (caller should use default).
 func (c *Config) GetClusterStateStabilityDuration() time.Duration {
 	return c.Cluster.ClusterStateStabilityDuration
+}
+
+// GetDefaultCallTimeout returns the configured default CallObject timeout.
+// Returns 0 if not configured (caller should use default).
+func (c *Config) GetDefaultCallTimeout() time.Duration {
+	return c.Cluster.DefaultCallTimeout
+}
+
+// GetDefaultCreateTimeout returns the configured default CreateObject timeout.
+// Returns 0 if not configured (caller should use default).
+func (c *Config) GetDefaultCreateTimeout() time.Duration {
+	return c.Cluster.DefaultCreateTimeout
+}
+
+// GetDefaultDeleteTimeout returns the configured default DeleteObject timeout.
+// Returns 0 if not configured (caller should use default).
+func (c *Config) GetDefaultDeleteTimeout() time.Duration {
+	return c.Cluster.DefaultDeleteTimeout
 }
 
 // GetInspectorAdvertiseAddress returns the inspector advertise address.

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -730,6 +730,87 @@ nodes:
 	}
 }
 
+func TestDefaultOperationTimeouts(t *testing.T) {
+	configContent := `
+version: 1
+
+cluster:
+  shards: 8192
+  provider: "etcd"
+  etcd:
+    endpoints:
+      - "127.0.0.1:2379"
+    prefix: "/goverse"
+  default_call_timeout: 45s
+  default_create_timeout: 12s
+  default_delete_timeout: 7s
+
+nodes:
+  - id: "node-1"
+    grpc_addr: "0.0.0.0:9101"
+    advertise_addr: "node-1.local:9101"
+`
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "config.yml")
+	if err := os.WriteFile(configPath, []byte(configContent), 0600); err != nil {
+		t.Fatalf("failed to write config file: %v", err)
+	}
+
+	cfg, err := LoadConfig(configPath)
+	if err != nil {
+		t.Fatalf("LoadConfig failed: %v", err)
+	}
+
+	if got := cfg.GetDefaultCallTimeout(); got != 45*time.Second {
+		t.Fatalf("GetDefaultCallTimeout() = %v, want 45s", got)
+	}
+	if got := cfg.GetDefaultCreateTimeout(); got != 12*time.Second {
+		t.Fatalf("GetDefaultCreateTimeout() = %v, want 12s", got)
+	}
+	if got := cfg.GetDefaultDeleteTimeout(); got != 7*time.Second {
+		t.Fatalf("GetDefaultDeleteTimeout() = %v, want 7s", got)
+	}
+}
+
+func TestDefaultOperationTimeoutsOptional(t *testing.T) {
+	configContent := `
+version: 1
+
+cluster:
+  shards: 8192
+  provider: "etcd"
+  etcd:
+    endpoints:
+      - "127.0.0.1:2379"
+    prefix: "/goverse"
+
+nodes:
+  - id: "node-1"
+    grpc_addr: "0.0.0.0:9101"
+    advertise_addr: "node-1.local:9101"
+`
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "config.yml")
+	if err := os.WriteFile(configPath, []byte(configContent), 0600); err != nil {
+		t.Fatalf("failed to write config file: %v", err)
+	}
+
+	cfg, err := LoadConfig(configPath)
+	if err != nil {
+		t.Fatalf("LoadConfig failed: %v", err)
+	}
+
+	if got := cfg.GetDefaultCallTimeout(); got != 0 {
+		t.Fatalf("GetDefaultCallTimeout() = %v, want 0", got)
+	}
+	if got := cfg.GetDefaultCreateTimeout(); got != 0 {
+		t.Fatalf("GetDefaultCreateTimeout() = %v, want 0", got)
+	}
+	if got := cfg.GetDefaultDeleteTimeout(); got != 0 {
+		t.Fatalf("GetDefaultDeleteTimeout() = %v, want 0", got)
+	}
+}
+
 func TestGetInspectorAdvertiseAddress(t *testing.T) {
 	tests := []struct {
 		name         string

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -93,6 +93,9 @@ Cluster-level configuration for distributed coordination.
 | `provider` | string | Yes | - | Cluster coordination provider. Currently only `"etcd"` is supported. |
 | `etcd` | object | Yes | - | etcd-specific configuration. |
 | `cluster_state_stability_duration` | duration | No | `10s` | How long the node list must be stable before updating shard mapping. |
+| `default_call_timeout` | duration | No | `30s` | Default timeout applied to `CallObject` when the caller context has no deadline. |
+| `default_create_timeout` | duration | No | `30s` | Default timeout applied to `CreateObject` when the caller context has no deadline. |
+| `default_delete_timeout` | duration | No | `30s` | Default timeout applied to `DeleteObject` when the caller context has no deadline. |
 | `auto_load_objects` | array | No | `[]` | List of objects to automatically load when a node starts. See [cluster.auto_load_objects](#clusterauto_load_objects). |
 
 #### cluster.etcd

--- a/node/serverconfig/serverconfig.go
+++ b/node/serverconfig/serverconfig.go
@@ -114,6 +114,9 @@ func (l *Loader) Load(args []string) (*server.ServerConfig, error) {
 			NodeStabilityDuration: cfg.GetClusterStateStabilityDuration(),
 			InspectorAddress:      cfg.GetInspectorAdvertiseAddress(),
 			AutoLoadObjects:       cfg.GetAutoLoadObjects(),
+			DefaultCallTimeout:    cfg.GetDefaultCallTimeout(),
+			DefaultCreateTimeout:  cfg.GetDefaultCreateTimeout(),
+			DefaultDeleteTimeout:  cfg.GetDefaultDeleteTimeout(),
 			ConfigFile:            cfg, // Pass the loaded config file
 		}, nil
 	}

--- a/node/serverconfig/serverconfig_test.go
+++ b/node/serverconfig/serverconfig_test.go
@@ -506,6 +506,51 @@ nodes:
 	}
 }
 
+func TestLoaderWithDefaultOperationTimeouts(t *testing.T) {
+	configContent := `
+version: 1
+
+cluster:
+  shards: 4096
+  provider: "etcd"
+  etcd:
+    endpoints:
+      - "etcd-cluster:2379"
+    prefix: "/goverse-test"
+  default_call_timeout: 45s
+  default_create_timeout: 12s
+  default_delete_timeout: 7s
+
+nodes:
+  - id: "node-1"
+    grpc_addr: "0.0.0.0:9101"
+    advertise_addr: "node-1.local:9101"
+`
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "config.yaml")
+	if err := os.WriteFile(configPath, []byte(configContent), 0600); err != nil {
+		t.Fatalf("failed to write config file: %v", err)
+	}
+
+	fs := flag.NewFlagSet("test", flag.ContinueOnError)
+	loader := NewLoader(fs)
+
+	cfg, err := loader.Load([]string{"-config", configPath, "-node-id", "node-1"})
+	if err != nil {
+		t.Fatalf("Load failed: %v", err)
+	}
+
+	if cfg.DefaultCallTimeout != 45*time.Second {
+		t.Errorf("expected DefaultCallTimeout 45s, got %v", cfg.DefaultCallTimeout)
+	}
+	if cfg.DefaultCreateTimeout != 12*time.Second {
+		t.Errorf("expected DefaultCreateTimeout 12s, got %v", cfg.DefaultCreateTimeout)
+	}
+	if cfg.DefaultDeleteTimeout != 7*time.Second {
+		t.Errorf("expected DefaultDeleteTimeout 7s, got %v", cfg.DefaultDeleteTimeout)
+	}
+}
+
 func TestLoaderWithAutoLoadObjects(t *testing.T) {
 	// Create a temp config file with auto_load_objects
 	configContent := `

--- a/server/server.go
+++ b/server/server.go
@@ -43,7 +43,11 @@ type ServerConfig struct {
 	AccessValidator           *config.AccessValidator       // Optional: access validator for node access control
 	LifecycleValidator        *config.LifecycleValidator    // Optional: lifecycle validator for CREATE/DELETE control
 	AutoLoadObjects           []config.AutoLoadObjectConfig // Optional: objects to auto-load when node starts and claims shards
-	ConfigFile                *config.Config                // Optional: loaded config file (if config file was used)
+	// Default timeouts applied when caller context has no deadline. Zero means use built-in defaults.
+	DefaultCallTimeout   time.Duration
+	DefaultCreateTimeout time.Duration
+	DefaultDeleteTimeout time.Duration
+	ConfigFile           *config.Config // Optional: loaded config file (if config file was used)
 }
 
 type Server struct {
@@ -101,6 +105,15 @@ func NewServer(config *ServerConfig) (*Server, error) {
 	}
 	if len(config.AutoLoadObjects) > 0 {
 		clusterCfg.AutoLoadObjects = config.AutoLoadObjects
+	}
+	if config.DefaultCallTimeout > 0 {
+		clusterCfg.DefaultCallTimeout = config.DefaultCallTimeout
+	}
+	if config.DefaultCreateTimeout > 0 {
+		clusterCfg.DefaultCreateTimeout = config.DefaultCreateTimeout
+	}
+	if config.DefaultDeleteTimeout > 0 {
+		clusterCfg.DefaultDeleteTimeout = config.DefaultDeleteTimeout
 	}
 	if config.ConfigFile != nil {
 		clusterCfg.ConfigFile = config.ConfigFile


### PR DESCRIPTION
## Summary
- Surface the existing `cluster.Config.DefaultCallTimeout` / `DefaultCreateTimeout` / `DefaultDeleteTimeout` fields through YAML as `cluster.default_call_timeout` / `default_create_timeout` / `default_delete_timeout`.
- Plumb them through `server.ServerConfig` and `node/serverconfig` so a config-file node picks them up.
- Document the three knobs in `docs/CONFIGURATION.md`.

Companion to #506 (metric emission). Together these complete the v0.1.0 "Default Timeout Enforcement" milestone item.

## Test plan
- [x] `go build ./...`
- [x] `go test ./config/...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)