### PR TITLE
Defer graceful shutdown mode to v0.2.0

### DIFF
--- a/docs/MILESTONE_V0.1.0.md
+++ b/docs/MILESTONE_V0.1.0.md
@@ -35,19 +35,7 @@ These were prerequisites — now complete:
 
 **Reference**: `docs/TIMEOUT_DESIGN.md`
 
-#### 2. Graceful Shutdown Mode (P1)
-
-**Why**: Restart and scale-down behave differently. Restart should keep shard assignments for fast reclaim; scale-down should release shards proactively. (Rolling updates and drains in any orchestrator — systemd, Docker, Kubernetes — rely on this distinction.)
-
-**Scope**:
-- Add shutdown mode parameter: `graceful` (release shards) vs `fast` (keep assignments)
-- For graceful mode: release shards before unregistering, with configurable timeout
-- Block new object creation during graceful shutdown
-- Document when to use each mode (restart → fast, permanent scale-down → graceful)
-
-**Reference**: `SHARDING_TODO.md` P1
-
-#### 3. Watch Reconnection on Disconnect (P1)
+#### 2. Watch Reconnection on Disconnect (P1)
 
 **Why**: If the etcd watch channel closes (network blip, etcd restart, compaction), the `watchPrefix` goroutine exits and is never restarted. The node's in-memory cluster state becomes permanently stale — it stops seeing node joins/leaves, shard changes, and leader updates. This silently breaks the entire cluster from that node's perspective.
 
@@ -59,7 +47,7 @@ These were prerequisites — now complete:
 
 **Reference**: `cluster/consensusmanager/consensusmanager.go` `watchPrefix()`
 
-#### 4. Getting Started Guide
+#### 3. Getting Started Guide
 
 **Why**: No amount of code quality matters if people can't figure out how to use it. Currently README has a quick start, but no end-to-end tutorial.
 
@@ -77,6 +65,9 @@ During shard migration (TargetNode ≠ CurrentNode), `GetCurrentNodeForObject` r
 
 #### Shard Lock Has No Timeout
 Shard lock acquisition (`AcquireRead`/`AcquireWrite`) has no context or timeout. In theory a stuck holder could block all operations on that shard forever. In practice, all etcd operations under the lock already have `WithEtcdDeadline` (60s), so the lock holder won't hang indefinitely. Adding context-aware locking is a nice-to-have but not required for v0.1.0.
+
+#### Graceful Shutdown Mode
+Scale-down currently relies on etcd lease expiry: when a node stops, its lease lapses, the leader detects the dead node, and its shards are reassigned. This is correct but slower than a proactive release by roughly one lease TTL. A dedicated "clean" shutdown mode that releases shards before exiting is an operational optimization, not a correctness fix, and is deferred to v0.2.0. Tracked in PR #494 (closed).
 
 ### 🚫 Explicitly Out of Scope
 
@@ -102,9 +93,8 @@ These are important but deferred to future milestones:
 |---|------|-----------------|--------------|
 | 1 | Default Timeout Enforcement | Large | None |
 | 2 | Watch Reconnection on Disconnect | Small-Medium | None |
-| 3 | Graceful Shutdown Mode | Medium | None |
-| 4 | Getting Started Guide + Sample App | Medium | 1-3 (need stable behavior to document) |
-| 5 | Tag v0.1.0 | — | All above |
+| 3 | Getting Started Guide + Sample App | Medium | 1-2 (need stable behavior to document) |
+| 4 | Tag v0.1.0 | — | All above |
 
 ---
 


### PR DESCRIPTION
## Summary
- Lease expiry already handles node disappearance correctly; a clean-shutdown path only shortens scale-down handoff by ~one lease TTL
- Remove graceful shutdown from v0.1.0 Must Do, renumber remaining items, record rationale under Known Issues (Deferred)
- PRs #494 and #509 closed with pointers to v0.2.0

Remaining v0.1.0 items: default timeouts (done), watch reconnection (done), getting started guide.

## Test plan
- [x] Doc-only change