### PR TITLE
Enforce default call timeout in ReliableCallObject

### DIFF
--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -874,6 +874,11 @@ func (c *Cluster) ReliableCallObjectAnyRequest(ctx context.Context, callID strin
 		return nil, goverse_pb.ReliableCallStatus_SKIPPED, fmt.Errorf("methodName cannot be empty")
 	}
 
+	// Enforce default call timeout. Without this, a deadline-less ctx lets the
+	// RPC retry loop below run forever on persistent RPC failures.
+	ctx, cancel := context.WithTimeout(ctx, effectiveTimeout(c.config.DefaultCallTimeout, DefaultCallTimeout))
+	defer cancel()
+
 	// Find the target node FIRST (before INSERT)
 	// This ensures INSERT happens on the owner node with proper locking
 	// Pre-execution error - method never executed, so SKIPPED


### PR DESCRIPTION
## Summary
- `ReliableCallObjectAnyRequest` had no default-timeout wrap. Its exponential-backoff retry loop exits only on `ctx.Done()`, so a caller passing `context.Background()` against a persistently-failing target would loop forever
- Mirror the existing wrap from `CallObject` (cluster.go:560), `CreateObject` (:681), `DeleteObject` (:772): `context.WithTimeout(ctx, effectiveTimeout(config.DefaultCallTimeout, DefaultCallTimeout))`
- `WithTimeout` returns the sooner of the existing deadline and the new one, so callers with shorter deadlines are unaffected

Found during a context-handling audit of the v0.1.0 codebase.

## Test plan
- [x] `go build ./...` + `go vet ./cluster/...`
- [x] Existing `TestReliableCallObjectAnyRequest` passes (no regression)
- Behavioral coverage for the default-timeout wraps is currently config-level across all four entry points (`CallObject`/`CreateObject`/`DeleteObject`/now `ReliableCallObject`). Adding end-to-end "does it actually terminate under timeout" tests is a broader task — happy to add one here if you'd prefer