### PR TITLE
Cut v0.1.0: CHANGELOG entry and README status refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,48 @@
+# Changelog
 
+All notable changes to GoVerse are documented in this file.
+
+## [0.1.0] — 2026-04-19
+
+First tagged release. GoVerse is a distributed object runtime for Go that
+implements the virtual actor model with etcd-based placement and 8192-shard
+sharding. External users can deploy GoVerse, run a distributed application,
+and trust that basic failure modes are handled correctly.
+
+### Added
+
+- **Core runtime**: virtual objects with automatic lifecycle & activation;
+  Node + Gate architecture; streaming gRPC and HTTP REST APIs.
+- **Exactly-once call semantics**: `ReliableCallObject` for inter-object
+  calls that tolerate retries and node failures.
+- **Sharded placement**: 8192-shard model with dynamic object & shard
+  rebalancing across nodes.
+- **Default timeouts**: `DefaultCallTimeout`, `DefaultCreateTimeout`,
+  `EtcdOperationTimeout`, and `ConnectionTimeout` on `ServerConfig` /
+  `GateServerConfig` / `ClusterConfig`, configurable via YAML.
+- **Timeout observability**: `TimeoutError` type with `IsTimeout(err)`
+  helper (gRPC-aware); `goverse_operation_timeouts_total` and
+  `goverse_operation_duration_seconds` metrics.
+- **Watch reconnection**: etcd watch auto-reconnects with exponential
+  backoff after disconnects or compaction, preventing stale cluster state.
+- **Persistence**: PostgreSQL with JSONB storage.
+- **Observability**: Prometheus metrics, pprof profiling, Inspector UI.
+- **Push messaging**: real-time server-to-client delivery, including
+  `BroadcastToAllClients`.
+- **Operations**: `/healthz` and `/ready` endpoints on node and inspector;
+  production Dockerfiles for node, gate, and inspector; reference
+  Kubernetes manifests under `k8s/`; `docker-compose.yml` for local etcd
+  and Postgres.
+- **Docs**: end-to-end "5-Minute Tour" in `docs/GET_STARTED.md`; full
+  getting-started guide, API reference, HTTP gate spec, and design docs.
+- **Samples**: `counter`, `tictactoe`, `chat`, `sharding_demo`.
+
+### Known Issues (deferred to v0.2.0)
+
+- **Migration-period unavailability**: during shard handoff,
+  `GetCurrentNodeForObject` errors even though the current node is still
+  alive — causes brief unavailability during rebalance.
+- **Graceful shutdown**: scale-down relies on etcd lease expiry rather
+  than a proactive shard release.
+- **No built-in access control / TLS**: deploy in a private network or
+  behind a service mesh until v0.2.0.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ GoVerse is a distributed object runtime for Go, inspired by Orleans.
 It provides virtual actors, automatic placement, lifecycle management, and streaming RPCs.  
 Designed for building fault-tolerant backend services and large-scale real-time systems.
 
-> ⚠️ **EARLY DEVELOPMENT STAGE** - This project is in very early development. APIs are unstable and may change significantly. Not recommended for production use.
+> **v0.1.0 — first tagged release.** Core concepts (objects, nodes, gates) are settled and basic failure modes are handled. APIs may still change before v1.0. Production use is at your own risk; see [CHANGELOG.md](CHANGELOG.md) for known issues.
 
 ---
 
@@ -182,11 +182,11 @@ Full documentation:
 
 ## Status & Roadmap
 
-Current status: **Alpha**
+Current status: **v0.1.0** — first tagged release. See [CHANGELOG.md](CHANGELOG.md) for what's in and [docs/MILESTONE_V0.1.0.md](docs/MILESTONE_V0.1.0.md) for the release criteria.
 
-Near-term goals: stability improvements, enhanced benchmarks, Inspector UI v2
+Near-term goals (v0.2.0): access control and auth, TLS/mTLS, graceful shutdown mode, observability improvements.
 
-See [Getting Started](docs/GET_STARTED.md) for detailed roadmap and contribution guidelines.
+See [Getting Started](docs/GET_STARTED.md) for the end-to-end tutorial and contribution guidelines.
 
 ---
 


### PR DESCRIPTION
## Summary
- Populates the empty `CHANGELOG.md` with a v0.1.0 entry (features shipped + known issues deferred to v0.2.0)
- Drops the "EARLY DEVELOPMENT" warning and "Alpha" status from `README.md` in favor of v0.1.0 framing that points at `CHANGELOG.md`
- Last item from MILESTONE_V0.1.0.md release criteria before the tag

## Test plan
- [x] Doc-only change
- [x] Reviewed `MILESTONE_V0.1.0.md` to verify scope — the changelog covers the three "Must Do" items (default timeouts, watch reconnection, getting started guide) and lists the three documented "Known Issues (Deferred)" under the same framing

🤖 Generated with [Claude Code](https://claude.com/claude-code)