### PR TITLE
Bind async Create/DeleteObject goroutines to cluster liveCtx

### DIFF
--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -84,8 +84,8 @@ type Cluster struct {
 	minQuorum                 int           // minimal number of nodes required for cluster to be considered stable
 	numShards                 int           // number of shards in this cluster
 	shardMappingCheckInterval time.Duration // how often to check if shard mapping needs updating
-	clusterManagementCtx      context.Context
-	clusterManagementCancel   context.CancelFunc
+	liveCtx                   context.Context
+	liveCancel                context.CancelFunc
 	clusterManagementRunning  bool
 	clusterReadyChan          chan bool
 	clusterReadyOnce          sync.Once
@@ -181,6 +181,11 @@ func NewClusterWithGate(cfg Config, g *gate.Gate) (*Cluster, error) {
 }
 
 func (c *Cluster) init(cfg Config) error {
+	// Initialize the cluster-live ctx up front so background work launched before
+	// Start() (or in tests that never call Start) has a non-nil parent to bind
+	// to. Start() reassigns this ctx to a child of its own ctx.
+	c.liveCtx, c.liveCancel = context.WithCancel(context.Background())
+
 	// Initialization logic for the cluster
 	// Set the cluster's ShardLock on the node immediately for per-cluster isolation
 	// Note: Gates don't need ShardLock as they don't host objects
@@ -235,7 +240,7 @@ func newClusterForTesting(node *node.Node, name string) *Cluster {
 	// Use testutil.TestNumShards for consistency with test node configuration
 	numShards := testutil.TestNumShards
 	shardLock := shardlock.NewShardLock(numShards)
-	return &Cluster{
+	c := &Cluster{
 		node:                      node,
 		logger:                    logger.NewLogger(name),
 		clusterReadyChan:          make(chan bool),
@@ -247,6 +252,8 @@ func newClusterForTesting(node *node.Node, name string) *Cluster {
 		shardLock:                 shardLock,
 		gateChannels:              make(map[string]chan proto.Message),
 	}
+	c.liveCtx, c.liveCancel = context.WithCancel(context.Background())
+	return c
 }
 
 // newClusterWithEtcdForTesting creates a new cluster instance for testing and initializes it with etcd
@@ -696,7 +703,7 @@ func (c *Cluster) CreateObject(ctx context.Context, objType, objID string) (resu
 	// Check if the object should be created on this node (only for node clusters)
 	if c.isNode() && nodeAddr == c.getAdvertiseAddr() {
 		go func() {
-			asyncCtx, asyncCancel := context.WithTimeout(context.Background(), effectiveTimeout(c.config.DefaultCreateTimeout, DefaultCreateTimeout))
+			asyncCtx, asyncCancel := context.WithTimeout(c.liveCtx, effectiveTimeout(c.config.DefaultCreateTimeout, DefaultCreateTimeout))
 			defer asyncCancel()
 			c.logger.Infof("%s - Async creating object %s locally (type: %s)", c, objID, objType)
 			_, err := c.node.CreateObject(asyncCtx, objType, objID)
@@ -743,7 +750,7 @@ func (c *Cluster) CreateObject(ctx context.Context, objType, objID string) (resu
 	} else {
 		// Asynchronous execution for nodes to prevent deadlocks
 		go func() {
-			asyncCtx, asyncCancel := context.WithTimeout(context.Background(), effectiveTimeout(c.config.DefaultCreateTimeout, DefaultCreateTimeout))
+			asyncCtx, asyncCancel := context.WithTimeout(c.liveCtx, effectiveTimeout(c.config.DefaultCreateTimeout, DefaultCreateTimeout))
 			defer asyncCancel()
 			if _, asyncErr := client.CreateObject(asyncCtx, req); asyncErr != nil {
 				c.logger.Errorf("%s - Async CreateObject %s failed on remote node: %v", c, objID, asyncErr)
@@ -784,7 +791,7 @@ func (c *Cluster) DeleteObject(ctx context.Context, objID string) (err error) {
 	// Check if the object should be deleted on this node (only for node clusters)
 	if c.isNode() && nodeAddr == c.getAdvertiseAddr() {
 		go func() {
-			asyncCtx, asyncCancel := context.WithTimeout(context.Background(), effectiveTimeout(c.config.DefaultDeleteTimeout, DefaultDeleteTimeout))
+			asyncCtx, asyncCancel := context.WithTimeout(c.liveCtx, effectiveTimeout(c.config.DefaultDeleteTimeout, DefaultDeleteTimeout))
 			defer asyncCancel()
 			// Delete locally
 			c.logger.Infof("%s - Async deleting object %s locally", c, objID)
@@ -827,7 +834,7 @@ func (c *Cluster) DeleteObject(ctx context.Context, objID string) (err error) {
 	} else {
 		// Asynchronous execution for nodes to prevent deadlocks
 		go func() {
-			asyncCtx, asyncCancel := context.WithTimeout(context.Background(), effectiveTimeout(c.config.DefaultDeleteTimeout, DefaultDeleteTimeout))
+			asyncCtx, asyncCancel := context.WithTimeout(c.liveCtx, effectiveTimeout(c.config.DefaultDeleteTimeout, DefaultDeleteTimeout))
 			defer asyncCancel()
 			if _, asyncErr := client.DeleteObject(asyncCtx, req); asyncErr != nil {
 				c.logger.Errorf("%s - Async DeleteObject %s failed on remote node: %v", c, objID, asyncErr)
@@ -1461,7 +1468,12 @@ func (c *Cluster) startClusterManagement(ctx context.Context) error {
 		return nil
 	}
 
-	c.clusterManagementCtx, c.clusterManagementCancel = context.WithCancel(ctx)
+	// Replace the constructor-seeded ctx with one tied to the Start() ctx, so
+	// cancellation of the caller's ctx propagates to cluster background work.
+	if c.liveCancel != nil {
+		c.liveCancel()
+	}
+	c.liveCtx, c.liveCancel = context.WithCancel(ctx)
 	c.clusterManagementRunning = true
 
 	go c.clusterManagementLoop()
@@ -1473,9 +1485,9 @@ func (c *Cluster) startClusterManagement(ctx context.Context) error {
 
 // stopShardMappingManagement stops the shard mapping management background task
 func (c *Cluster) stopShardMappingManagement() {
-	if c.clusterManagementCancel != nil {
-		c.clusterManagementCancel()
-		c.clusterManagementCancel = nil
+	if c.liveCancel != nil {
+		c.liveCancel()
+		c.liveCancel = nil
 	}
 	c.clusterManagementRunning = false
 	c.logger.Infof("%s - Stopped shard mapping management", c)
@@ -1488,7 +1500,7 @@ func (c *Cluster) clusterManagementLoop() {
 
 	for {
 		select {
-		case <-c.clusterManagementCtx.Done():
+		case <-c.liveCtx.Done():
 			c.logger.Debugf("%s - Shard mapping management loop stopped", c)
 			return
 		case <-ticker.C:
@@ -1508,7 +1520,7 @@ func (c *Cluster) clusterManagementTick() {
 
 // handleShardMappingCheck checks and updates shard mapping based on leadership and node stability
 func (c *Cluster) handleShardMappingCheck() {
-	ctx := c.clusterManagementCtx
+	ctx := c.liveCtx
 
 	// Try to become leader if no leader exists or current leader is dead
 	if err := c.tryBecomeLeader(); err != nil {
@@ -1545,7 +1557,7 @@ func (c *Cluster) tryBecomeLeader() error {
 	if !c.isNode() {
 		return nil
 	}
-	return c.consensusManager.TryBecomeLeader(c.clusterManagementCtx)
+	return c.consensusManager.TryBecomeLeader(c.liveCtx)
 }
 
 func (c *Cluster) updateMetrics() {

--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -181,9 +181,9 @@ func NewClusterWithGate(cfg Config, g *gate.Gate) (*Cluster, error) {
 }
 
 func (c *Cluster) init(cfg Config) error {
-	// Initialize the cluster-live ctx up front so background work launched before
-	// Start() (or in tests that never call Start) has a non-nil parent to bind
-	// to. Start() reassigns this ctx to a child of its own ctx.
+	// Initialize the cluster-live ctx up front. It bounds all cluster-live
+	// background work (async Create/DeleteObject goroutines, the shard
+	// management loop, etc.) and is cancelled by Cluster.Stop.
 	c.liveCtx, c.liveCancel = context.WithCancel(context.Background())
 
 	// Initialization logic for the cluster
@@ -331,7 +331,7 @@ func (c *Cluster) Start(ctx context.Context, n *node.Node) error {
 	}
 
 	// Start shard mapping management
-	if err := c.startClusterManagement(ctx); err != nil {
+	if err := c.startClusterManagement(); err != nil {
 		return fmt.Errorf("failed to start shard mapping management: %w", err)
 	}
 
@@ -353,6 +353,14 @@ func (c *Cluster) Start(ctx context.Context, n *node.Node) error {
 // 5. Closes the etcd connection
 func (c *Cluster) Stop(ctx context.Context) error {
 	c.logger.Infof("%s - Stopping cluster...", c)
+
+	// Cancel the cluster-live ctx up front so any async background work
+	// (Create/DeleteObject goroutines, shard management loop, etc.) unwinds
+	// while the rest of shutdown runs.
+	if c.liveCancel != nil {
+		c.liveCancel()
+		c.liveCancel = nil
+	}
 
 	// Stop node connections
 	c.stopNodeConnections()
@@ -702,8 +710,9 @@ func (c *Cluster) CreateObject(ctx context.Context, objType, objID string) (resu
 
 	// Check if the object should be created on this node (only for node clusters)
 	if c.isNode() && nodeAddr == c.getAdvertiseAddr() {
+		liveCtx := c.liveCtx
 		go func() {
-			asyncCtx, asyncCancel := context.WithTimeout(c.liveCtx, effectiveTimeout(c.config.DefaultCreateTimeout, DefaultCreateTimeout))
+			asyncCtx, asyncCancel := context.WithTimeout(liveCtx, effectiveTimeout(c.config.DefaultCreateTimeout, DefaultCreateTimeout))
 			defer asyncCancel()
 			c.logger.Infof("%s - Async creating object %s locally (type: %s)", c, objID, objType)
 			_, err := c.node.CreateObject(asyncCtx, objType, objID)
@@ -749,8 +758,9 @@ func (c *Cluster) CreateObject(ctx context.Context, objType, objID string) (resu
 		return objID, nil
 	} else {
 		// Asynchronous execution for nodes to prevent deadlocks
+		liveCtx := c.liveCtx
 		go func() {
-			asyncCtx, asyncCancel := context.WithTimeout(c.liveCtx, effectiveTimeout(c.config.DefaultCreateTimeout, DefaultCreateTimeout))
+			asyncCtx, asyncCancel := context.WithTimeout(liveCtx, effectiveTimeout(c.config.DefaultCreateTimeout, DefaultCreateTimeout))
 			defer asyncCancel()
 			if _, asyncErr := client.CreateObject(asyncCtx, req); asyncErr != nil {
 				c.logger.Errorf("%s - Async CreateObject %s failed on remote node: %v", c, objID, asyncErr)
@@ -790,8 +800,9 @@ func (c *Cluster) DeleteObject(ctx context.Context, objID string) (err error) {
 	}
 	// Check if the object should be deleted on this node (only for node clusters)
 	if c.isNode() && nodeAddr == c.getAdvertiseAddr() {
+		liveCtx := c.liveCtx
 		go func() {
-			asyncCtx, asyncCancel := context.WithTimeout(c.liveCtx, effectiveTimeout(c.config.DefaultDeleteTimeout, DefaultDeleteTimeout))
+			asyncCtx, asyncCancel := context.WithTimeout(liveCtx, effectiveTimeout(c.config.DefaultDeleteTimeout, DefaultDeleteTimeout))
 			defer asyncCancel()
 			// Delete locally
 			c.logger.Infof("%s - Async deleting object %s locally", c, objID)
@@ -833,8 +844,9 @@ func (c *Cluster) DeleteObject(ctx context.Context, objID string) (err error) {
 		return nil
 	} else {
 		// Asynchronous execution for nodes to prevent deadlocks
+		liveCtx := c.liveCtx
 		go func() {
-			asyncCtx, asyncCancel := context.WithTimeout(c.liveCtx, effectiveTimeout(c.config.DefaultDeleteTimeout, DefaultDeleteTimeout))
+			asyncCtx, asyncCancel := context.WithTimeout(liveCtx, effectiveTimeout(c.config.DefaultDeleteTimeout, DefaultDeleteTimeout))
 			defer asyncCancel()
 			if _, asyncErr := client.DeleteObject(asyncCtx, req); asyncErr != nil {
 				c.logger.Errorf("%s - Async DeleteObject %s failed on remote node: %v", c, objID, asyncErr)
@@ -1462,18 +1474,12 @@ func (c *Cluster) GetNodeForShard(ctx context.Context, shardID int) (string, err
 // If this node is the leader and the node list has been stable for the configured node stability duration,
 // it will update/initialize the shard mapping.
 // If this node is not the leader, it will periodically refresh the shard mapping from etcd.
-func (c *Cluster) startClusterManagement(ctx context.Context) error {
+func (c *Cluster) startClusterManagement() error {
 	if c.clusterManagementRunning {
 		c.logger.Warnf("%s - Shard mapping management already running", c)
 		return nil
 	}
 
-	// Replace the constructor-seeded ctx with one tied to the Start() ctx, so
-	// cancellation of the caller's ctx propagates to cluster background work.
-	if c.liveCancel != nil {
-		c.liveCancel()
-	}
-	c.liveCtx, c.liveCancel = context.WithCancel(ctx)
 	c.clusterManagementRunning = true
 
 	go c.clusterManagementLoop()
@@ -1483,12 +1489,9 @@ func (c *Cluster) startClusterManagement(ctx context.Context) error {
 	return nil
 }
 
-// stopShardMappingManagement stops the shard mapping management background task
+// stopShardMappingManagement stops the shard mapping management background task.
+// The liveCtx that drives the loop is cancelled by Cluster.Stop directly.
 func (c *Cluster) stopShardMappingManagement() {
-	if c.liveCancel != nil {
-		c.liveCancel()
-		c.liveCancel = nil
-	}
 	c.clusterManagementRunning = false
 	c.logger.Infof("%s - Stopped shard mapping management", c)
 }

--- a/cluster/cluster_livectx_test.go
+++ b/cluster/cluster_livectx_test.go
@@ -1,0 +1,103 @@
+package cluster
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+// TestClusterLiveCtxSeededByConstructor verifies the cluster constructor path
+// seeds liveCtx so fire-and-forget goroutines have a non-nil parent even when
+// Start() has not been called.
+func TestClusterLiveCtxSeededByConstructor(t *testing.T) {
+	c := newClusterForTesting(nil, "test-livectx-seeded")
+	if c.liveCtx == nil {
+		t.Fatal("liveCtx should be seeded by the constructor")
+	}
+	if err := c.liveCtx.Err(); err != nil {
+		t.Fatalf("liveCtx should not be cancelled initially: %v", err)
+	}
+	if c.liveCancel == nil {
+		t.Fatal("liveCancel should be seeded by the constructor")
+	}
+}
+
+// TestClusterLiveCtxBoundsAsyncWork exercises the pattern used by the async
+// Create/DeleteObject sites: capture c.liveCtx locally before launching a
+// goroutine, then derive a WithTimeout child. Cancelling liveCtx (as Stop
+// does) must unblock the goroutine promptly.
+func TestClusterLiveCtxBoundsAsyncWork(t *testing.T) {
+	c := newClusterForTesting(nil, "test-livectx-bounds")
+
+	// Capture liveCtx on the caller's goroutine, exactly like CreateObject does.
+	liveCtx := c.liveCtx
+
+	done := make(chan struct{})
+	go func() {
+		// Simulate the async goroutine pattern: wrap with a long default timeout
+		// and block until the ctx is cancelled.
+		asyncCtx, asyncCancel := context.WithTimeout(liveCtx, 30*time.Second)
+		defer asyncCancel()
+		<-asyncCtx.Done()
+		close(done)
+	}()
+
+	// Cancel liveCtx — this is what Cluster.Stop does.
+	c.liveCancel()
+
+	select {
+	case <-done:
+		// Async goroutine exited promptly via ctx cancellation.
+	case <-time.After(2 * time.Second):
+		t.Fatal("async goroutine did not exit after liveCancel")
+	}
+
+	if c.liveCtx.Err() != context.Canceled {
+		t.Fatalf("liveCtx should be cancelled, got: %v", c.liveCtx.Err())
+	}
+}
+
+// TestClusterLiveCtxCapturePinsLifecycle verifies that goroutines capture
+// liveCtx at call time. If a future lifecycle swap ever reassigned c.liveCtx
+// (it currently doesn't, but the capture pattern defends against it), the
+// already-launched goroutine must still bind to the original ctx.
+func TestClusterLiveCtxCapturePinsLifecycle(t *testing.T) {
+	c := newClusterForTesting(nil, "test-livectx-capture")
+
+	// Launch a goroutine that captures liveCtx locally, as the async sites do.
+	liveCtx := c.liveCtx
+	started := make(chan struct{})
+	observed := make(chan error, 1)
+	go func() {
+		close(started)
+		<-liveCtx.Done()
+		observed <- liveCtx.Err()
+	}()
+	<-started
+
+	// Simulate a lifecycle swap: rebind c.liveCtx to a fresh ctx. The running
+	// goroutine must NOT latch onto this new ctx — it must see the original
+	// one cancel.
+	oldCancel := c.liveCancel
+	c.liveCtx, c.liveCancel = context.WithCancel(context.Background())
+
+	// Cancel the original ctx. The goroutine should observe this, not the new one.
+	oldCancel()
+
+	select {
+	case err := <-observed:
+		if err != context.Canceled {
+			t.Fatalf("goroutine observed unexpected err: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("goroutine did not observe cancellation of the pinned liveCtx")
+	}
+
+	// The new liveCtx should still be live.
+	if err := c.liveCtx.Err(); err != nil {
+		t.Fatalf("new liveCtx should not be cancelled: %v", err)
+	}
+
+	// Clean up.
+	c.liveCancel()
+}


### PR DESCRIPTION
## Summary
- Fixes a goroutine-leak potential flagged in the recent context/goroutine audit: the four fire-and-forget async goroutines in `Cluster.CreateObject`/`Cluster.DeleteObject` used `context.WithTimeout(context.Background(), ...)`, so they survived `Cluster.Stop()` and kept holding node/etcd refs until their individual timeout elapsed.
- Swaps the parent to a cluster-scoped ctx (`c.liveCtx`) that `Stop()` cancels, so async work exits promptly when the cluster shuts down.
- Renames `clusterManagementCtx`/`clusterManagementCancel` → `liveCtx`/`liveCancel` — the ctx now bounds all cluster-live background work, not just the shard-mapping management loop.
- Seeds `liveCtx` in `init()` and in the testing constructor so callers that never invoke `Start()` get a non-nil parent.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./cluster/...`
- [x] `go test -count=1 -p 1 ./cluster/...` — passes
- [x] `go test -count=1 -p 1 -timeout 10m ./...` — only unrelated postgres auth failures (env mismatch: test user `postgres` vs docker-compose user `goverse`), present on `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)