### PR TITLE
Preserve persistent state during shard migration

### DIFF
--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -1752,18 +1752,19 @@ func (c *Cluster) removeObjectsNotBelongingToThisNode(ctx context.Context) {
 	objectsToEvict := c.consensusManager.GetObjectsToEvict(localAddr, objectIDs)
 	c.logger.Infof("%s - Found %d objects out of %d to evict from this node", c, len(objectsToEvict), len(objectIDs))
 
-	// Remove each object that should be evicted
+	// Evict each object whose shard no longer belongs to this node. Eviction
+	// preserves persisted state so the new shard owner can reactivate the
+	// object on first access (the virtual-actor reactivation contract).
 	for _, objectID := range objectsToEvict {
 		shardID := sharding.GetShardID(objectID, c.numShards)
-		c.logger.Infof("%s - Removing object %s (shard %d) as it no longer belongs to this node", c,
+		c.logger.Infof("%s - Evicting object %s (shard %d) as it no longer belongs to this node", c,
 			objectID, shardID)
 
-		err := c.node.DeleteObject(ctx, objectID)
+		err := c.node.EvictObject(ctx, objectID)
 		if err != nil {
-			c.logger.Errorf("%s - Failed to delete object %s: %v", c, objectID, err)
+			c.logger.Errorf("%s - Failed to evict object %s: %v", c, objectID, err)
 		} else {
-			c.logger.Infof("%s - Successfully removed object %s", c, objectID)
-			// Metrics are not recorded for evicted objects since we don't track object types here
+			c.logger.Infof("%s - Successfully evicted object %s", c, objectID)
 		}
 	}
 }

--- a/cluster/cluster_migration_persistence_test.go
+++ b/cluster/cluster_migration_persistence_test.go
@@ -1,0 +1,212 @@
+package cluster
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/xiaonanln/goverse/cluster/sharding"
+	"github.com/xiaonanln/goverse/object"
+	"github.com/xiaonanln/goverse/util/testutil"
+	clientv3 "go.etcd.io/etcd/client/v3"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/structpb"
+)
+
+// sharedMockProvider is a minimal PersistenceProvider backed by an in-memory map
+// shared between nodes so that what node1 persists, node2 can later load.
+type sharedMockProvider struct {
+	mu         sync.Mutex
+	storage    map[string][]byte
+	nextRcseqs map[string]int64
+}
+
+func newSharedMockProvider() *sharedMockProvider {
+	return &sharedMockProvider{
+		storage:    make(map[string][]byte),
+		nextRcseqs: make(map[string]int64),
+	}
+}
+
+func (m *sharedMockProvider) SaveObject(ctx context.Context, objectID, objectType string, data []byte, nextRcseq int64) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.storage[objectID] = data
+	m.nextRcseqs[objectID] = nextRcseq
+	return nil
+}
+
+func (m *sharedMockProvider) LoadObject(ctx context.Context, objectID string) ([]byte, int64, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	data, ok := m.storage[objectID]
+	if !ok {
+		return nil, 0, nil
+	}
+	return data, m.nextRcseqs[objectID], nil
+}
+
+func (m *sharedMockProvider) DeleteObject(ctx context.Context, objectID string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	delete(m.storage, objectID)
+	delete(m.nextRcseqs, objectID)
+	return nil
+}
+
+func (m *sharedMockProvider) InsertOrGetReliableCall(ctx context.Context, requestID, objectID, objectType, methodName string, requestData []byte) (*object.ReliableCall, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+func (m *sharedMockProvider) UpdateReliableCallStatus(ctx context.Context, seq int64, status string, resultData []byte, errorMessage string) error {
+	return fmt.Errorf("not implemented")
+}
+
+func (m *sharedMockProvider) GetPendingReliableCalls(ctx context.Context, objectID string, nextRcseq int64) ([]*object.ReliableCall, error) {
+	return nil, nil
+}
+
+func (m *sharedMockProvider) GetReliableCallBySeq(ctx context.Context, seq int64) (*object.ReliableCall, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+func (m *sharedMockProvider) hasStoredData(objectID string) bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	_, ok := m.storage[objectID]
+	return ok
+}
+
+// MigratablePersistentObject is a persistent object whose state the runtime
+// saves via the provider. The specific state doesn't matter for this test —
+// the bug is about the provider row being deleted, not about the value.
+type MigratablePersistentObject struct {
+	object.BaseObject
+}
+
+func (o *MigratablePersistentObject) OnCreated() {}
+
+func (o *MigratablePersistentObject) ToData() (proto.Message, error) {
+	return structpb.NewStruct(map[string]any{"present": true})
+}
+
+func (o *MigratablePersistentObject) FromData(data proto.Message) error { return nil }
+
+// TestShardMigration_PreservesPersistentState verifies the virtual-actor
+// reactivation contract (docs/SHARDING.md): when a shard migrates, the old
+// owner evicts local objects but must leave their persisted state intact so
+// the new owner can reactivate them on first access. Previously eviction
+// called Node.DeleteObject, which also wiped the persistence row — silently
+// losing all object state on every rebalance. The fix introduces
+// Node.EvictObject, which flushes latest state then drops the in-memory
+// instance without touching persistence.
+func TestShardMigration_PreservesPersistentState(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.Skip("Skipping long-running integration test in short mode")
+	}
+
+	testPrefix := testutil.PrepareEtcdPrefix(t, "localhost:2379")
+	ctx := context.Background()
+
+	node1Addr := testutil.GetFreeAddress()
+	node2Addr := testutil.GetFreeAddress()
+	cluster1 := mustNewCluster(ctx, t, node1Addr, testPrefix)
+	cluster2 := mustNewCluster(ctx, t, node2Addr, testPrefix)
+
+	node1 := cluster1.GetThisNode()
+	node2 := cluster2.GetThisNode()
+
+	// Shared persistence so node2 can reactivate what node1 persisted.
+	provider := newSharedMockProvider()
+	node1.SetPersistenceProvider(provider)
+	node2.SetPersistenceProvider(provider)
+
+	node1.RegisterObjectType((*MigratablePersistentObject)(nil))
+	node2.RegisterObjectType((*MigratablePersistentObject)(nil))
+
+	// Start mock gRPC servers so cross-node CreateObject routing works.
+	mockServer1 := testutil.NewMockGoverseServer()
+	mockServer1.SetNode(node1)
+	testServer1 := testutil.NewTestServerHelper(node1Addr, mockServer1)
+	if err := testServer1.Start(ctx); err != nil {
+		t.Fatalf("Failed to start mock server 1: %v", err)
+	}
+	t.Cleanup(func() { testServer1.Stop() })
+
+	mockServer2 := testutil.NewMockGoverseServer()
+	mockServer2.SetNode(node2)
+	testServer2 := testutil.NewTestServerHelper(node2Addr, mockServer2)
+	if err := testServer2.Start(ctx); err != nil {
+		t.Fatalf("Failed to start mock server 2: %v", err)
+	}
+	t.Cleanup(func() { testServer2.Stop() })
+
+	testutil.WaitForClustersReady(t, cluster1, cluster2)
+
+	// Find an object ID that routes to node1 so we can later migrate its shard to node2.
+	var objID string
+	var shardID int
+	for i := range 1000 {
+		candidate := fmt.Sprintf("migrate-persist-obj-%d", i)
+		owner, err := cluster1.GetCurrentNodeForObject(ctx, candidate)
+		if err != nil {
+			continue
+		}
+		if owner == node1Addr {
+			objID = candidate
+			shardID = sharding.GetShardID(candidate, testutil.TestNumShards)
+			break
+		}
+	}
+	if objID == "" {
+		t.Skip("Could not find an object ID routed to node1 within 1000 candidates")
+	}
+	t.Logf("Selected object %s on shard %d (initial owner: node1)", objID, shardID)
+
+	// Create the object and persist its state.
+	if _, err := cluster1.CreateObject(ctx, "MigratablePersistentObject", objID); err != nil {
+		t.Fatalf("CreateObject failed: %v", err)
+	}
+	waitForObjectCreated(t, node1, objID, 5*time.Second)
+
+	if err := node1.SaveAllObjects(ctx); err != nil {
+		t.Fatalf("SaveAllObjects failed: %v", err)
+	}
+	if !provider.hasStoredData(objID) {
+		t.Fatalf("precondition: persisted data for %s should exist after SaveAllObjects", objID)
+	}
+	t.Logf("Persisted state confirmed for %s", objID)
+
+	// Force-migrate the shard from node1 → node2 by writing directly to etcd.
+	etcdClient, err := clientv3.New(clientv3.Config{
+		Endpoints:   []string{"localhost:2379"},
+		DialTimeout: 5 * time.Second,
+	})
+	if err != nil {
+		t.Fatalf("Failed to connect to etcd: %v", err)
+	}
+	defer etcdClient.Close()
+
+	key := fmt.Sprintf("%s/shard/%d", testPrefix, shardID)
+	value := fmt.Sprintf("%s,%s", node2Addr, node1Addr) // targetNode=node2, currentNode=node1
+	if _, err := etcdClient.Put(ctx, key, value); err != nil {
+		t.Fatalf("Failed to update shard %d: %v", shardID, err)
+	}
+	t.Logf("Reassigned shard %d: targetNode=%s, currentNode=%s", shardID, node2Addr, node1Addr)
+
+	// Wait for node1 to evict the object.
+	waitForObjectRemoved(t, node1, objID, testutil.WaitForShardMappingTimeout)
+	t.Logf("Object %s evicted from node1 after shard migration", objID)
+
+	// The critical assertion: the persisted state must survive eviction so that
+	// node2 can reactivate the object with its prior value (500), as promised by
+	// the virtual-actor reactivation contract in docs/SHARDING.md:141-145.
+	if !provider.hasStoredData(objID) {
+		t.Fatalf("persisted state for %s was deleted during shard migration; "+
+			"the new owner can no longer reactivate the object", objID)
+	}
+	t.Logf("Persisted state survived migration — reactivation will succeed")
+}

--- a/node/node.go
+++ b/node/node.go
@@ -854,6 +854,51 @@ func (node *Node) DeleteObject(ctx context.Context, id string) error {
 	return nil
 }
 
+// EvictObject removes an object from this node's in-memory map without deleting
+// its persisted state. It flushes the latest state to the persistence provider
+// first so the new shard owner can reactivate the object with an up-to-date
+// snapshot (see docs/SHARDING.md: objects are virtual actors, reactivated on
+// the new node on first access after migration). For user-initiated deletion
+// that also removes persistence, use DeleteObject.
+func (node *Node) EvictObject(ctx context.Context, id string) error {
+	node.stopMu.RLock()
+	defer node.stopMu.RUnlock()
+
+	if node.stopped.Load() {
+		return nil
+	}
+
+	unlockKey := node.objectLifecycleLock.Lock(id)
+	defer unlockKey()
+
+	node.objectsMu.RLock()
+	obj, exists := node.objects[id]
+	node.objectsMu.RUnlock()
+
+	if !exists {
+		return nil
+	}
+
+	// Flush latest state to persistence before destroying the in-memory instance
+	// so the new owner can reactivate with up-to-date data. Save errors block
+	// destruction — we'd rather the object stay in memory and retry next tick
+	// than lose state.
+	node.persistenceProviderMu.RLock()
+	provider := node.persistenceProvider
+	node.persistenceProviderMu.RUnlock()
+
+	if provider != nil {
+		if err := obj.Save(provider); err != nil && !errors.Is(err, object.ErrNotPersistent) {
+			node.logger.Errorf("Failed to save object %s before eviction: %v", id, err)
+			return fmt.Errorf("failed to save before eviction: %w", err)
+		}
+	}
+
+	node.destroyObject(id)
+	node.logger.Infof("Evicted object %s from node (persistence preserved)", id)
+	return nil
+}
+
 func (node *Node) NumObjects() int {
 	node.objectsMu.RLock()
 	defer node.objectsMu.RUnlock()


### PR DESCRIPTION
## Summary

- **Bug:** Shard eviction called `Node.DeleteObject`, which also deletes the persistence row. This silently dropped all persistent object state on every rebalance — a virtual-actor runtime that loses state on migration is broken.
- **Contract violated:** `docs/SHARDING.md:141-145` promises objects are reactivated on the new node on first access after migration. Reactivation requires the persisted row to still exist.
- **Fix:** Introduce `Node.EvictObject(ctx, id)`. It flushes latest state via `obj.Save(provider)`, then drops the in-memory instance — without calling `provider.DeleteObject`. `Cluster.removeObjectsNotBelongingToThisNode` now uses it.
- **`DeleteObject` is unchanged** — still the user-initiated permanent-delete path.

## Why the bug wasn't caught

- `TestClusterRemoveObjectsNotBelongingToThisNode` uses a non-persistent object type, so eviction's call to `provider.DeleteObject` was a no-op.
- Stress tests (`samples/sharding_demo/stress_test_demo.py`, `tests/samples/chat/stress/stress_test.py`) start a stable topology and never trigger rebalancing, so migration paths never fire.

## New regression test

`cluster/cluster_migration_persistence_test.go::TestShardMigration_PreservesPersistentState`

- Starts two clusters with a shared in-memory persistence provider.
- Creates a persistent object on node1 and flushes it via `SaveAllObjects`.
- Force-reassigns its shard to node2 by writing directly to etcd.
- Waits for node1 to evict the object.
- **Asserts** the persisted row still exists — i.e. node2 can reactivate on next call.

Without the fix this test fails with clear bug logs (`Deleting object ... from persistence` / `Successfully deleted object ...`). With the fix it passes and the log reads `Evicted object ... from node (persistence preserved)`.

## Test plan

- [x] `go test -run TestShardMigration_PreservesPersistentState ./cluster/` — passes
- [x] `go test -p 1 ./cluster/...` — all pass (129s)
- [x] `go test -p 1 ./node/...` — all pass
- [x] `go vet ./...` clean, `go fmt ./...` clean
- [ ] CI on all platforms

## Follow-up (not in this PR)

- Add a node-churn mode to the stress tests that kills/restarts a node mid-run, to exercise the migration path under load. The current stress tests only hit the stable-topology code path, which is why this bug survived to v0.1.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)