### PR TITLE
Move schema init out of node startup into pgadmin

### DIFF
--- a/.github/workflows/stress.yml
+++ b/.github/workflows/stress.yml
@@ -79,6 +79,9 @@ jobs:
           sudo -u postgres psql -c "GRANT ALL PRIVILEGES ON DATABASE goverse TO goverse;"
           sudo -u postgres psql -d goverse -c "GRANT ALL ON SCHEMA public TO goverse;"
 
+      - name: Initialize Goverse schema
+        run: go run ./cmd/pgadmin --config samples/sharding_demo/stress_config_demo.yml init
+
       - name: Install PyYAML
         run: python3 -m pip install pyyaml
 

--- a/samples/sharding_demo/STRESS_TEST_README.md
+++ b/samples/sharding_demo/STRESS_TEST_README.md
@@ -41,6 +41,14 @@ The `stress_test_demo.py` script performs comprehensive stress testing of the de
    ./script/compile-proto.sh
    ```
 
+5. **Postgres** - The stress test uses Postgres-backed persistence. Start it and initialize the schema once:
+   ```bash
+   # From the repo root
+   docker compose up -d postgres
+   go run ./cmd/pgadmin --config samples/sharding_demo/stress_config_demo.yml init
+   ```
+   Re-run the `pgadmin init` command only when the schema changes; nodes fail fast on startup if the schema is missing.
+
 ## Usage
 
 ### Basic Usage

--- a/server/server.go
+++ b/server/server.go
@@ -171,9 +171,10 @@ func NewServer(config *ServerConfig) (*Server, error) {
 	return server, nil
 }
 
-// openPostgresPersistence opens the Postgres connection, initializes the schema,
-// and returns a ready DB. Runs before node/cluster construction so the server
-// refuses to start when the database is misconfigured or unreachable.
+// openPostgresPersistence opens the Postgres connection and preflights the
+// expected schema. Schema provisioning is out-of-band (`goverse pgadmin init`);
+// the node refuses to start if the tables are missing so the failure is loud
+// and happens before any writes land.
 func openPostgresPersistence(ctx context.Context, pgCfg *config.PostgresConfig) (*postgres.DB, error) {
 	sslMode := pgCfg.SSLMode
 	if sslMode == "" {
@@ -200,14 +201,32 @@ func openPostgresPersistence(ctx context.Context, pgCfg *config.PostgresConfig) 
 		return nil, fmt.Errorf("ping database: %w", err)
 	}
 
-	initCtx, initCancel := context.WithTimeout(ctx, 30*time.Second)
-	defer initCancel()
-	if err := db.InitSchema(initCtx); err != nil {
+	checkCtx, checkCancel := context.WithTimeout(ctx, 10*time.Second)
+	defer checkCancel()
+	if err := preflightGoverseSchema(checkCtx, db); err != nil {
 		db.Close()
-		return nil, fmt.Errorf("init schema: %w", err)
+		return nil, err
 	}
 
 	return db, nil
+}
+
+// preflightGoverseSchema fails fast when the expected Goverse tables are
+// missing, pointing the operator at the pgadmin init command rather than
+// letting the first SaveObject surface a cryptic "relation does not exist".
+func preflightGoverseSchema(ctx context.Context, db *postgres.DB) error {
+	const query = `
+		SELECT to_regclass('public.goverse_objects') IS NOT NULL
+		   AND to_regclass('public.goverse_reliable_calls') IS NOT NULL
+	`
+	var ready bool
+	if err := db.Connection().QueryRowContext(ctx, query).Scan(&ready); err != nil {
+		return fmt.Errorf("check schema: %w", err)
+	}
+	if !ready {
+		return fmt.Errorf("goverse schema not initialized: run `go run ./cmd/pgadmin --config <config.yml> init` before starting nodes")
+	}
+	return nil
 }
 
 func validateServerConfig(config *ServerConfig) error {

--- a/server/server.go
+++ b/server/server.go
@@ -214,10 +214,14 @@ func openPostgresPersistence(ctx context.Context, pgCfg *config.PostgresConfig) 
 // preflightGoverseSchema fails fast when the expected Goverse tables are
 // missing, pointing the operator at the pgadmin init command rather than
 // letting the first SaveObject surface a cryptic "relation does not exist".
+//
+// Table names are passed unqualified so they resolve via the connection's
+// search_path, matching how the persistence queries (and pgadmin init) refer
+// to them. This keeps non-public schema deployments working.
 func preflightGoverseSchema(ctx context.Context, db *postgres.DB) error {
 	const query = `
-		SELECT to_regclass('public.goverse_objects') IS NOT NULL
-		   AND to_regclass('public.goverse_reliable_calls') IS NOT NULL
+		SELECT to_regclass('goverse_objects') IS NOT NULL
+		   AND to_regclass('goverse_reliable_calls') IS NOT NULL
 	`
 	var ready bool
 	if err := db.Connection().QueryRowContext(ctx, query).Scan(&ready); err != nil {


### PR DESCRIPTION
## Summary
Follow-up to #516. Addresses the InitSchema single-call coordination question by moving provisioning out of node startup entirely, rather than trying to serialize concurrent DDL at runtime.

- Nodes no longer call `InitSchema` on boot. Schema is provisioned out-of-band with the existing `cmd/pgadmin init` command, so the catalog race that surfaced with concurrent node starts simply doesn't exist.
- `server.openPostgresPersistence` preflights the schema via `to_regclass()` for `goverse_objects` / `goverse_reliable_calls`. Missing schema yields a clear "run `go run ./cmd/pgadmin --config <config.yml> init` before starting nodes" error instead of a cryptic "relation does not exist" on the first `SaveObject`.
- CI demo-stress-test runs `go run ./cmd/pgadmin --config samples/sharding_demo/stress_config_demo.yml init` right after provisioning the `goverse` role, before launching the stress run.
- `STRESS_TEST_README.md` documents the one-time init step for local dev.

## Test plan
- [x] `go build ./...` / `go fmt` / `go vet` clean
- [x] `go test ./server/... ./util/postgres/... ./cmd/pgadmin/...` (Postgres integration tests against docker-compose with `goverse` creds)
- [x] Dropped the schema locally, ran the demo node — preflight panics with the expected message pointing at `pgadmin init`
- [x] Ran `go run ./cmd/pgadmin ... init`, confirmed tables created; server starts cleanly on the next run

🤖 Generated with [Claude Code](https://claude.com/claude-code)