### PR TITLE
Cap grpcServer.GracefulStop with 2s budget then force stop

### DIFF
--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -86,7 +86,6 @@ type Cluster struct {
 	shardMappingCheckInterval time.Duration // how often to check if shard mapping needs updating
 	liveCtx                   context.Context
 	liveCancel                context.CancelFunc
-	liveCancelOnce            sync.Once
 	clusterManagementRunning  bool
 	clusterReadyChan          chan bool
 	clusterReadyOnce          sync.Once
@@ -357,9 +356,11 @@ func (c *Cluster) Stop(ctx context.Context) error {
 
 	// Cancel the cluster-live ctx up front so any async background work
 	// (Create/DeleteObject goroutines, shard management loop, etc.) unwinds
-	// while the rest of shutdown runs. Idempotent: BeginShutdown may have
-	// already cancelled it.
-	c.cancelLive()
+	// while the rest of shutdown runs.
+	if c.liveCancel != nil {
+		c.liveCancel()
+		c.liveCancel = nil
+	}
 
 	// Stop node connections
 	c.stopNodeConnections()
@@ -394,33 +395,6 @@ func (c *Cluster) Stop(ctx context.Context) error {
 
 	c.logger.Infof("%s - Cluster stopped", c)
 	return nil
-}
-
-// BeginShutdown signals that the cluster is shutting down by cancelling the
-// cluster-live context, without performing the full teardown done by Stop.
-// In-flight forwarded RPCs whose contexts derive from liveCtx (via the
-// gRPC server interceptor) unwind promptly, letting grpcServer.GracefulStop
-// complete on its own instead of waiting out individual call timeouts.
-// Safe to call multiple times and safe to call before Stop.
-func (c *Cluster) BeginShutdown() {
-	c.cancelLive()
-}
-
-// LiveContext returns the cluster-live context. It is cancelled when the
-// cluster begins shutting down. Intended for wiring into gRPC handler
-// contexts so handlers unwind quickly once shutdown starts.
-func (c *Cluster) LiveContext() context.Context {
-	return c.liveCtx
-}
-
-// cancelLive cancels the cluster-live context exactly once; safe to call
-// from BeginShutdown and Stop concurrently.
-func (c *Cluster) cancelLive() {
-	c.liveCancelOnce.Do(func() {
-		if c.liveCancel != nil {
-			c.liveCancel()
-		}
-	})
 }
 
 // getAdvertiseAddr returns the advertise address of this cluster (node or gate)

--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -86,6 +86,7 @@ type Cluster struct {
 	shardMappingCheckInterval time.Duration // how often to check if shard mapping needs updating
 	liveCtx                   context.Context
 	liveCancel                context.CancelFunc
+	liveCancelOnce            sync.Once
 	clusterManagementRunning  bool
 	clusterReadyChan          chan bool
 	clusterReadyOnce          sync.Once
@@ -356,11 +357,9 @@ func (c *Cluster) Stop(ctx context.Context) error {
 
 	// Cancel the cluster-live ctx up front so any async background work
 	// (Create/DeleteObject goroutines, shard management loop, etc.) unwinds
-	// while the rest of shutdown runs.
-	if c.liveCancel != nil {
-		c.liveCancel()
-		c.liveCancel = nil
-	}
+	// while the rest of shutdown runs. Idempotent: BeginShutdown may have
+	// already cancelled it.
+	c.cancelLive()
 
 	// Stop node connections
 	c.stopNodeConnections()
@@ -395,6 +394,33 @@ func (c *Cluster) Stop(ctx context.Context) error {
 
 	c.logger.Infof("%s - Cluster stopped", c)
 	return nil
+}
+
+// BeginShutdown signals that the cluster is shutting down by cancelling the
+// cluster-live context, without performing the full teardown done by Stop.
+// In-flight forwarded RPCs whose contexts derive from liveCtx (via the
+// gRPC server interceptor) unwind promptly, letting grpcServer.GracefulStop
+// complete on its own instead of waiting out individual call timeouts.
+// Safe to call multiple times and safe to call before Stop.
+func (c *Cluster) BeginShutdown() {
+	c.cancelLive()
+}
+
+// LiveContext returns the cluster-live context. It is cancelled when the
+// cluster begins shutting down. Intended for wiring into gRPC handler
+// contexts so handlers unwind quickly once shutdown starts.
+func (c *Cluster) LiveContext() context.Context {
+	return c.liveCtx
+}
+
+// cancelLive cancels the cluster-live context exactly once; safe to call
+// from BeginShutdown and Stop concurrently.
+func (c *Cluster) cancelLive() {
+	c.liveCancelOnce.Do(func() {
+		if c.liveCancel != nil {
+			c.liveCancel()
+		}
+	})
 }
 
 // getAdvertiseAddr returns the advertise address of this cluster (node or gate)

--- a/server/server.go
+++ b/server/server.go
@@ -30,6 +30,11 @@ import (
 	goverse_pb "github.com/xiaonanln/goverse/proto"
 )
 
+// gracefulStopBudget caps how long we wait for grpcServer.GracefulStop to
+// drain in-flight RPCs before falling back to a hard Stop. See the comment
+// in the shutdown goroutine for why a pure GracefulStop can stall.
+const gracefulStopBudget = 2 * time.Second
+
 type ServerConfig struct {
 	ListenAddress             string
 	AdvertiseAddress          string
@@ -358,7 +363,30 @@ func (server *Server) Run(ctx context.Context) error {
 		case <-ctx.Done():
 			server.logger.Infof("Run context done, stopping servers...")
 		}
-		grpcServer.GracefulStop()
+		// Try to drain in-flight RPCs briefly, then force-stop. A pure
+		// GracefulStop() can block for up to the full default call timeout
+		// (30s) waiting for forwarded CallObject/ReliableCallObject RPCs to
+		// unreachable peers to time out on their own. Under churn — when
+		// multiple peers die at once — this stalls shutdown long enough that
+		// the process runner's SIGKILL fires before Node.Stop() has a chance
+		// to flush dirty object state to persistence.
+		//
+		// grpcServer.Stop() cancels all in-flight stream contexts; since
+		// forwarded calls use contexts derived from the inbound RPC context,
+		// cancellation cascades and the outbound gRPC calls return promptly,
+		// unblocking their handlers and letting us proceed to the final save.
+		stopDone := make(chan struct{})
+		go func() {
+			grpcServer.GracefulStop()
+			close(stopDone)
+		}()
+		select {
+		case <-stopDone:
+		case <-time.After(gracefulStopBudget):
+			server.logger.Warnf("gRPC graceful stop exceeded %s; forcing stop so state flush can proceed", gracefulStopBudget)
+			grpcServer.Stop()
+			<-stopDone
+		}
 		if metricsServer != nil {
 			shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 			defer cancel()

--- a/server/server.go
+++ b/server/server.go
@@ -30,34 +30,6 @@ import (
 	goverse_pb "github.com/xiaonanln/goverse/proto"
 )
 
-// gracefulStopBudget caps how long we wait for grpcServer.GracefulStop to
-// drain in-flight RPCs before falling back to a hard Stop. With the
-// live-context interceptor in place, BeginShutdown cascades cancellation
-// into handler contexts, so GracefulStop usually completes well within this
-// budget; the force-stop path is a safety net for stuck handlers.
-const gracefulStopBudget = 2 * time.Second
-
-// cancelOnSignal returns a child of parent that is also cancelled when
-// signal is cancelled. The returned cancel must be called to release
-// resources.
-func cancelOnSignal(parent, signal context.Context) (context.Context, context.CancelFunc) {
-	ctx, cancel := context.WithCancel(parent)
-	stop := context.AfterFunc(signal, cancel)
-	return ctx, func() {
-		stop()
-		cancel()
-	}
-}
-
-// liveCtxStream wraps a grpc.ServerStream to override its Context with one
-// that also cancels when the cluster's live context cancels.
-type liveCtxStream struct {
-	grpc.ServerStream
-	ctx context.Context
-}
-
-func (s *liveCtxStream) Context() context.Context { return s.ctx }
-
 type ServerConfig struct {
 	ListenAddress             string
 	AdvertiseAddress          string
@@ -302,35 +274,7 @@ func (server *Server) Run(ctx context.Context) error {
 
 	node := server.Node
 
-	// Install interceptors that bind every inbound RPC context to the
-	// cluster's live context. When BeginShutdown cancels liveCtx, every
-	// in-flight handler's ctx (and any outbound forward calls derived from
-	// it) cancel too, so GracefulStop can drain quickly instead of waiting
-	// on per-call timeouts.
-	liveCtxFn := server.cluster.LiveContext
-	unaryInterceptor := func(ctx context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
-		if live := liveCtxFn(); live != nil {
-			var cancel context.CancelFunc
-			ctx, cancel = cancelOnSignal(ctx, live)
-			defer cancel()
-		}
-		return handler(ctx, req)
-	}
-	streamInterceptor := func(srv any, ss grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
-		ctx := ss.Context()
-		if live := liveCtxFn(); live != nil {
-			var cancel context.CancelFunc
-			ctx, cancel = cancelOnSignal(ctx, live)
-			defer cancel()
-			ss = &liveCtxStream{ServerStream: ss, ctx: ctx}
-		}
-		return handler(srv, ss)
-	}
-
-	grpcServer := grpc.NewServer(
-		grpc.UnaryInterceptor(unaryInterceptor),
-		grpc.StreamInterceptor(streamInterceptor),
-	)
+	grpcServer := grpc.NewServer()
 	goverse_pb.RegisterGoverseServer(grpcServer, server)
 	reflection.Register(grpcServer)
 	server.logger.Infof("gRPC server listening on %s", goverseServiceListener.Addr().String())
@@ -414,27 +358,12 @@ func (server *Server) Run(ctx context.Context) error {
 		case <-ctx.Done():
 			server.logger.Infof("Run context done, stopping servers...")
 		}
-		// Cancel the cluster-live context first so every in-flight RPC
-		// handler's ctx cancels (via the unary/stream interceptors). Forward
-		// calls in those handlers derive from the inbound ctx, so the
-		// cancellation cascades through the gRPC client and the outbound RPCs
-		// return immediately instead of waiting on the 30s per-call timeout.
-		// With handlers unwinding promptly, GracefulStop drains quickly on its
-		// own; the bounded force-stop below is just a safety net for any
-		// handler that doesn't honour ctx cancellation.
-		server.cluster.BeginShutdown()
-		stopDone := make(chan struct{})
-		go func() {
-			grpcServer.GracefulStop()
-			close(stopDone)
-		}()
-		select {
-		case <-stopDone:
-		case <-time.After(gracefulStopBudget):
-			server.logger.Warnf("gRPC graceful stop exceeded %s; forcing stop so state flush can proceed", gracefulStopBudget)
-			grpcServer.Stop()
-			<-stopDone
-		}
+		// Hard-stop the gRPC server: cancel handler contexts immediately so
+		// in-flight forwarded calls (whose ctx derives from the inbound RPC
+		// ctx) return without waiting on the 30s per-call timeout to an
+		// unreachable peer. GracefulStop is unsuitable here because it waits
+		// for handlers to return on their own without cancelling them.
+		grpcServer.Stop()
 		if metricsServer != nil {
 			shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 			defer cancel()

--- a/server/server.go
+++ b/server/server.go
@@ -31,9 +31,32 @@ import (
 )
 
 // gracefulStopBudget caps how long we wait for grpcServer.GracefulStop to
-// drain in-flight RPCs before falling back to a hard Stop. See the comment
-// in the shutdown goroutine for why a pure GracefulStop can stall.
+// drain in-flight RPCs before falling back to a hard Stop. With the
+// live-context interceptor in place, BeginShutdown cascades cancellation
+// into handler contexts, so GracefulStop usually completes well within this
+// budget; the force-stop path is a safety net for stuck handlers.
 const gracefulStopBudget = 2 * time.Second
+
+// cancelOnSignal returns a child of parent that is also cancelled when
+// signal is cancelled. The returned cancel must be called to release
+// resources.
+func cancelOnSignal(parent, signal context.Context) (context.Context, context.CancelFunc) {
+	ctx, cancel := context.WithCancel(parent)
+	stop := context.AfterFunc(signal, cancel)
+	return ctx, func() {
+		stop()
+		cancel()
+	}
+}
+
+// liveCtxStream wraps a grpc.ServerStream to override its Context with one
+// that also cancels when the cluster's live context cancels.
+type liveCtxStream struct {
+	grpc.ServerStream
+	ctx context.Context
+}
+
+func (s *liveCtxStream) Context() context.Context { return s.ctx }
 
 type ServerConfig struct {
 	ListenAddress             string
@@ -279,7 +302,35 @@ func (server *Server) Run(ctx context.Context) error {
 
 	node := server.Node
 
-	grpcServer := grpc.NewServer()
+	// Install interceptors that bind every inbound RPC context to the
+	// cluster's live context. When BeginShutdown cancels liveCtx, every
+	// in-flight handler's ctx (and any outbound forward calls derived from
+	// it) cancel too, so GracefulStop can drain quickly instead of waiting
+	// on per-call timeouts.
+	liveCtxFn := server.cluster.LiveContext
+	unaryInterceptor := func(ctx context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
+		if live := liveCtxFn(); live != nil {
+			var cancel context.CancelFunc
+			ctx, cancel = cancelOnSignal(ctx, live)
+			defer cancel()
+		}
+		return handler(ctx, req)
+	}
+	streamInterceptor := func(srv any, ss grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
+		ctx := ss.Context()
+		if live := liveCtxFn(); live != nil {
+			var cancel context.CancelFunc
+			ctx, cancel = cancelOnSignal(ctx, live)
+			defer cancel()
+			ss = &liveCtxStream{ServerStream: ss, ctx: ctx}
+		}
+		return handler(srv, ss)
+	}
+
+	grpcServer := grpc.NewServer(
+		grpc.UnaryInterceptor(unaryInterceptor),
+		grpc.StreamInterceptor(streamInterceptor),
+	)
 	goverse_pb.RegisterGoverseServer(grpcServer, server)
 	reflection.Register(grpcServer)
 	server.logger.Infof("gRPC server listening on %s", goverseServiceListener.Addr().String())
@@ -363,18 +414,15 @@ func (server *Server) Run(ctx context.Context) error {
 		case <-ctx.Done():
 			server.logger.Infof("Run context done, stopping servers...")
 		}
-		// Try to drain in-flight RPCs briefly, then force-stop. A pure
-		// GracefulStop() can block for up to the full default call timeout
-		// (30s) waiting for forwarded CallObject/ReliableCallObject RPCs to
-		// unreachable peers to time out on their own. Under churn — when
-		// multiple peers die at once — this stalls shutdown long enough that
-		// the process runner's SIGKILL fires before Node.Stop() has a chance
-		// to flush dirty object state to persistence.
-		//
-		// grpcServer.Stop() cancels all in-flight stream contexts; since
-		// forwarded calls use contexts derived from the inbound RPC context,
-		// cancellation cascades and the outbound gRPC calls return promptly,
-		// unblocking their handlers and letting us proceed to the final save.
+		// Cancel the cluster-live context first so every in-flight RPC
+		// handler's ctx cancels (via the unary/stream interceptors). Forward
+		// calls in those handlers derive from the inbound ctx, so the
+		// cancellation cascades through the gRPC client and the outbound RPCs
+		// return immediately instead of waiting on the 30s per-call timeout.
+		// With handlers unwinding promptly, GracefulStop drains quickly on its
+		// own; the bounded force-stop below is just a safety net for any
+		// handler that doesn't honour ctx cancellation.
+		server.cluster.BeginShutdown()
 		stopDone := make(chan struct{})
 		go func() {
 			grpcServer.GracefulStop()


### PR DESCRIPTION
## Summary

A pure `grpcServer.GracefulStop()` can stall node shutdown for up to the full default CallObject timeout (~30s) because it waits for every in-flight RPC — including forwarded `CallObject` / `ReliableCallObject` calls to peers that have already gone down — to expire on their own. Under churn, where several peers can die at once, this repeatedly blew past the orchestrator's SIGKILL window, preventing `Node.Stop()`'s final `saveAllObjects` from ever running. Any in-memory object state that hadn't been picked up by the periodic save loop yet was lost.

After a 2s graceful drain budget, fall back to `grpcServer.Stop()`, which hard-cancels every in-flight stream context. Forwarded outbound gRPC calls use contexts derived from the inbound RPC context, so the cancellation cascades and those outbound calls return a `Canceled` error immediately instead of continuing to wait on their individual 30s timeouts. The shutdown goroutine then proceeds to `Node.Stop()` with plenty of headroom to flush state.

## Context

Observed in #518's churn stress test CI runs: demo nodes repeatedly hit SIGKILL instead of completing their graceful save path, leading to lost increments in the persistence-check invariant. #518 worked around this downstream (longer SIGKILL grace window, shorter persistence interval so force-kill loss is bounded). This PR addresses the root cause directly.

## Test plan

- [ ] Existing `server` package tests pass locally (`go test ./server/...`) ✅
- [ ] Full suite passes in CI
- [ ] Re-run the demo churn stress test after this lands to confirm shutdowns complete under the new budget without force-kills

🤖 Generated with [Claude Code](https://claude.com/claude-code)