### PR TITLE
Fail loudly when demo server hangs on SIGTERM

### DIFF
--- a/samples/sharding_demo/DemoServer.py
+++ b/samples/sharding_demo/DemoServer.py
@@ -18,6 +18,15 @@ from BinaryHelper import BinaryHelper
 from PortHelper import get_free_port
 
 
+class DemoServerStopTimeout(RuntimeError):
+    """Raised when a demo server fails to exit within the SIGTERM grace.
+
+    Hanging on SIGTERM means the node is stuck somewhere in shutdown
+    (e.g. blocked persistence flush, deadlocked goroutine) — a real bug we
+    want to surface loudly instead of papering over with SIGKILL.
+    """
+
+
 class DemoServer:
     """Manages a Goverse demo server process."""
     
@@ -141,20 +150,25 @@ class DemoServer:
         print(f"Stopping {self.name}...")
 
         # SIGTERM grace must cover Node.Stop() persisting every in-memory
-        # object to Postgres. gRPC shutdown itself is near-instant now
-        # (server hard-stops the listener instead of draining), so the
-        # dominant cost is proportional to the number of dirty objects.
-        # 20s is a comfortable ceiling for the stress demo workload.
+        # object to Postgres. gRPC shutdown itself is near-instant (server
+        # hard-stops the listener instead of draining), so the dominant cost
+        # is proportional to the number of dirty objects. 20s is a
+        # comfortable ceiling for the stress demo workload.
+        #
+        # If SIGTERM doesn't return within the grace, we deliberately do NOT
+        # follow up with SIGKILL: a hang in graceful shutdown is a real bug
+        # (stuck persistence, deadlocked goroutine, lost shutdown signal)
+        # and SIGKILL would mask it. Raise instead so the test fails loudly
+        # and the leaked process stays around as evidence.
         try:
             self.process.send_signal(signal.SIGTERM)
             self.process.wait(timeout=20)
         except subprocess.TimeoutExpired:
-            # Force kill if graceful shutdown fails
-            print(f"⚠️  {self.name} did not stop gracefully, force killing...")
-            self.process.kill()
-            self.process.wait()
-        except Exception as e:
-            print(f"⚠️  Error stopping {self.name}: {e}")
+            pid = self.process.pid
+            raise DemoServerStopTimeout(
+                f"{self.name} (pid={pid}) did not exit within 20s of SIGTERM; "
+                "investigate the hang before re-running"
+            )
 
         self.process = None
         print(f"✅ {self.name} stopped")

--- a/samples/sharding_demo/stress_test_demo.py
+++ b/samples/sharding_demo/stress_test_demo.py
@@ -68,7 +68,7 @@ sys.path.insert(0, str(SAMPLES_DIR))
 CHAT_DIR = REPO_ROOT / 'tests' / 'samples' / 'chat'
 sys.path.insert(0, str(CHAT_DIR))
 
-from DemoServer import DemoServer
+from DemoServer import DemoServer, DemoServerStopTimeout
 from Inspector import Inspector
 from Gateway import Gateway
 
@@ -454,6 +454,15 @@ class ChurnController:
             print(f"\n🔄 [CHURN] Killing demo server idx={idx} node_id={target.node_id}")
             try:
                 target.close()
+            except DemoServerStopTimeout as e:
+                # SIGTERM grace exceeded — a real shutdown bug. Stop churn
+                # so we don't pile on more half-alive nodes (the leaked
+                # process still holds the port; replacement would fail to
+                # bind anyway).
+                print(f"❌ [CHURN] {e}")
+                self.failures += 1
+                self.stop_event.set()
+                return
             except Exception as e:
                 print(f"⚠️  [CHURN] error closing {target.name}: {e}")
 
@@ -697,7 +706,8 @@ Examples:
     clients = []
     churn_controller = None
     persistence_ok = True
-    
+    shutdown_timeouts: List[str] = []
+
     final_stats = StringIO()
 
     try:
@@ -893,20 +903,18 @@ Examples:
 
         print_stats(clients, file=final_stats)
 
-        return 0 if persistence_ok else 1
-
     except KeyboardInterrupt:
         print("\n\n⚠️  Test interrupted by user")
         if churn_controller is not None:
             churn_controller.stop()
         print_stats(clients, file=final_stats)
-        return 1
-        
+        persistence_ok = False
+
     except Exception as e:
         print(f"\n❌ Unexpected error: {e}")
         traceback.print_exc()
-        return 1
-        
+        persistence_ok = False
+
     finally:
         # Always clean up all processes
         print("\nCleaning up...")
@@ -926,7 +934,7 @@ Examples:
                 client.stop()
             except Exception as e:
                 print(f"⚠️  Error stopping client: {e}")
-        
+
         # Stop gateways
         print("Stopping gateways...")
         for gateway in gateways:
@@ -934,15 +942,21 @@ Examples:
                 gateway.close()
             except Exception as e:
                 print(f"⚠️  Error stopping gateway: {e}")
-        
+
         # Stop demo servers
         print("Stopping demo servers...")
         for server in reversed(demo_servers):
             try:
                 server.close()
+            except DemoServerStopTimeout as e:
+                # SIGTERM grace exceeded — record as a test failure but
+                # keep going so the rest of the servers still get a chance
+                # to flush state. The hung process is left as evidence.
+                print(f"❌ {e}")
+                shutdown_timeouts.append(server.name)
             except Exception as e:
                 print(f"⚠️  Error stopping server: {e}")
-        
+
         # Stop inspector
         if inspector is not None:
             try:
@@ -950,9 +964,15 @@ Examples:
                 inspector.close()
             except Exception as e:
                 print(f"⚠️  Error stopping inspector: {e}")
-        
+
+        if shutdown_timeouts:
+            print(f"\n❌ {len(shutdown_timeouts)} server(s) hung on SIGTERM: "
+                  f"{', '.join(shutdown_timeouts)}")
+
         print("✅ Cleanup complete")
         print(final_stats.getvalue())
+
+    return 0 if (persistence_ok and not shutdown_timeouts) else 1
 
 if __name__ == '__main__':
     sys.exit(main())


### PR DESCRIPTION
## Summary
- DemoServer.close() raises DemoServerStopTimeout instead of SIGKILL when the SIGTERM grace expires — masking a hang behind a force-kill hides real shutdown bugs.
- ChurnController treats a stop timeout as a failure and stops driving more churn (the hung process still holds the port; a replacement couldn't bind anyway).
- Stress test main tracks each timeout and exits non-zero. The hung process is left running as evidence for diagnosis.

## Test plan
- [x] Normal 60s churn run still passes (exit 0, all servers stopped cleanly)
- [x] Injected a SIGTERM-ignoring process — DemoServerStopTimeout is raised on grace exceedance

🤖 Generated with [Claude Code](https://claude.com/claude-code)