### PR TITLE
Record Node.Stop duration as a Prometheus histogram

### DIFF
--- a/node/node.go
+++ b/node/node.go
@@ -123,8 +123,16 @@ func (node *Node) IsStarted() bool {
 }
 
 // Stop stops the node and unregisters it from the inspector
-func (node *Node) Stop(ctx context.Context) error {
+func (node *Node) Stop(ctx context.Context) (err error) {
 	node.logger.Infof("Node stopping")
+	start := time.Now()
+	defer func() {
+		status := "success"
+		if err != nil {
+			status = "error"
+		}
+		metrics.RecordNodeStopDuration(node.advertiseAddress, status, time.Since(start).Seconds())
+	}()
 
 	// Set the stopped flag atomically to signal that no new operations should start
 	node.stopped.Store(true)

--- a/util/metrics/metrics.go
+++ b/util/metrics/metrics.go
@@ -188,6 +188,18 @@ var (
 		},
 		[]string{"node_addr", "outcome"},
 	)
+
+	// NodeStopDurationSeconds tracks how long Node.Stop takes, end to end.
+	// Most cost comes from the final persistence flush; buckets extend past
+	// the typical process supervisor SIGKILL window so stalls are visible.
+	NodeStopDurationSeconds = promauto.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:    "goverse_node_stop_duration_seconds",
+			Help:    "Duration of Node.Stop in seconds by node and status (success, error)",
+			Buckets: []float64{0.1, 0.5, 1, 2, 5, 10, 20, 30, 60, 120},
+		},
+		[]string{"node_addr", "status"},
+	)
 )
 
 // RecordObjectCreated increments the object count for a given node, type, and shard
@@ -311,4 +323,10 @@ func RecordOperationDuration(nodeAddr, operation, status string, duration float6
 // ("reconnected" on successful state reload, "reload_failed" when reload fails mid-retry).
 func RecordWatchReconnection(nodeAddr, outcome string) {
 	WatchReconnectionsTotal.WithLabelValues(nodeAddr, outcome).Inc()
+}
+
+// RecordNodeStopDuration records how long Node.Stop took, labeled by node and
+// status ("success" or "error").
+func RecordNodeStopDuration(nodeAddr, status string, duration float64) {
+	NodeStopDurationSeconds.WithLabelValues(nodeAddr, status).Observe(duration)
 }


### PR DESCRIPTION
## Summary
- Add `goverse_node_stop_duration_seconds` histogram (labeled by `node_addr` and `status`) to observe how long `Node.Stop` takes end-to-end.
- Instrument `Node.Stop` with a deferred observation so both success and error paths are recorded.
- Buckets span 0.1s–120s so supervisor-level shutdown stalls are visible before SIGKILL kicks in.

## Test plan
- [x] `go build ./...`
- [x] `go test ./util/metrics/... ./node/...`
- [ ] Confirm the metric appears in `/metrics` after a clean shutdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)