### PR TITLE
Skip GracefulStop on gate shutdown

### DIFF
--- a/gate/gateserver/gateserver.go
+++ b/gate/gateserver/gateserver.go
@@ -200,25 +200,13 @@ func (s *GateServer) Stop() error {
 	s.logger.Infof("Stopping gate server")
 
 	if s.grpcServer != nil {
-		// Create a timeout context for graceful shutdown (5 seconds)
-		shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 5*time.Second)
-		defer shutdownCancel()
-
-		// Graceful stop in goroutine
-		done := make(chan struct{})
-		go func() {
-			s.grpcServer.GracefulStop()
-			close(done)
-		}()
-
-		// Wait for graceful stop or timeout
-		select {
-		case <-done:
-			s.logger.Infof("gRPC server stopped gracefully")
-		case <-shutdownCtx.Done():
-			s.logger.Warnf("gRPC server shutdown timed out, forcing stop")
-			s.grpcServer.Stop()
-		}
+		// Hard-stop the gRPC server: the gate's Register RPC is a long-lived
+		// server-stream that exits only when the client disconnects, so
+		// GracefulStop has nothing meaningful to drain and would just sit
+		// for the full timeout before falling back to Stop anyway. Stop
+		// closes transports immediately, which cancels handler contexts so
+		// the streaming loops return at once.
+		s.grpcServer.Stop()
 	}
 
 	// Shutdown HTTP server if running


### PR DESCRIPTION
## Summary
- The gate's `Register` RPC is a long-lived server-stream that only returns when the client disconnects (`gateserver.go:251`), so `GracefulStop` has nothing meaningful to drain.
- Result: every shutdown sat for the full 5s timeout, then fell back to `Stop()` anyway and printed `gRPC server shutdown timed out, forcing stop` as a WARN.
- Mirror PR #522 (node side): drop the dance and call `Stop()` directly. Closing transports cancels handler contexts, the streaming loops fall through `<-ctx.Done()` immediately, and shutdown returns without the WARN.

## Test plan
- [x] `go build ./...`
- [x] `go test ./gate/...`
- [x] Re-run a stress and confirm the WARN no longer fires

🤖 Generated with [Claude Code](https://claude.com/claude-code)