### PR TITLE
Route postgres debug prints through the logger

### DIFF
--- a/util/postgres/db.go
+++ b/util/postgres/db.go
@@ -7,12 +7,14 @@ import (
 	"time"
 
 	_ "github.com/lib/pq"
+	"github.com/xiaonanln/goverse/util/logger"
 )
 
 // DB wraps a PostgreSQL database connection with utility methods
 type DB struct {
 	conn   *sql.DB
 	config *Config
+	logger *logger.Logger
 }
 
 // NewDB creates a new database connection using the provided configuration
@@ -46,6 +48,7 @@ func NewDB(config *Config) (*DB, error) {
 	return &DB{
 		conn:   conn,
 		config: config,
+		logger: logger.NewLogger("postgres"),
 	}, nil
 }
 

--- a/util/postgres/persistence.go
+++ b/util/postgres/persistence.go
@@ -185,8 +185,7 @@ func (db *DB) InsertOrGetReliableCall(ctx context.Context, requestID string, obj
 		RETURNING seq, call_id, object_id, object_type, method_name, request_data, result_data, error_message, status, created_at, updated_at
 	`
 
-	// Debug: Log the insert parameters
-	fmt.Printf("[DEBUG InsertOrGetReliableCall] call_id=%s, object_id=%s, object_type=%s, method_name=%s\n", requestID, objectID, objectType, methodName)
+	db.logger.Debugf("InsertOrGetReliableCall: call_id=%s, object_id=%s, object_type=%s, method_name=%s", requestID, objectID, objectType, methodName)
 
 	now := time.Now()
 	var rc object.ReliableCall
@@ -208,7 +207,7 @@ func (db *DB) InsertOrGetReliableCall(ctx context.Context, requestID string, obj
 	)
 
 	if err != nil {
-		fmt.Printf("[DEBUG InsertOrGetReliableCall] ERROR: %v\n", err)
+		db.logger.Debugf("InsertOrGetReliableCall: %v", err)
 		return nil, fmt.Errorf("failed to insert or get reliable call: %w", err)
 	}
 
@@ -219,8 +218,7 @@ func (db *DB) InsertOrGetReliableCall(ctx context.Context, requestID string, obj
 		rc.Error = errorMessage.String
 	}
 
-	// Debug: Log the inserted record
-	fmt.Printf("[DEBUG InsertOrGetReliableCall] Inserted: seq=%d, call_id=%s, object_id=%s, status=%s\n", rc.Seq, rc.CallID, rc.ObjectID, rc.Status)
+	db.logger.Debugf("InsertOrGetReliableCall: inserted seq=%d, call_id=%s, object_id=%s, status=%s", rc.Seq, rc.CallID, rc.ObjectID, rc.Status)
 
 	return &rc, nil
 }
@@ -271,8 +269,7 @@ func (db *DB) GetPendingReliableCalls(ctx context.Context, objectID string, next
 		ORDER BY seq ASC
 	`
 
-	// Debug: Log the query parameters
-	fmt.Printf("[DEBUG GetPendingReliableCalls] object_id=%s, nextRcseq=%d\n", objectID, nextRcseq)
+	db.logger.Debugf("GetPendingReliableCalls: object_id=%s, nextRcseq=%d", objectID, nextRcseq)
 
 	rows, err := db.conn.QueryContext(ctx, query, objectID, nextRcseq)
 	if err != nil {
@@ -319,7 +316,7 @@ func (db *DB) GetPendingReliableCalls(ctx context.Context, objectID string, next
 		return nil, fmt.Errorf("error iterating rows: %w", err)
 	}
 
-	fmt.Printf("[DEBUG GetPendingReliableCalls] Found %d rows\n", rowCount)
+	db.logger.Debugf("GetPendingReliableCalls: found %d rows", rowCount)
 
 	return calls, nil
 }


### PR DESCRIPTION
## Summary
- `util/postgres/persistence.go` had 5 stray `fmt.Printf("[DEBUG ...]")` traces on the reliable-call paths (`InsertOrGetReliableCall`, `GetPendingReliableCalls`). They bypass the logger entirely and dump to stdout on every call — ~338 lines in a 1-minute stress run, the biggest remaining source of log noise after PR #525.
- Add a `*logger.Logger` to `DB` (initialized in `NewDB` with prefix `postgres`), and convert the traces to `db.logger.Debugf`. They honour the package log level and disappear at the WARN default while staying available under DEBUG for diagnosis.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./util/postgres/...`
- [ ] Integration tests locally need postgres auth — verified no functional change via baseline failure-set diff
- [ ] Re-run a short stress to confirm the `[DEBUG GetPendingReliableCalls]` lines are gone

🤖 Generated with [Claude Code](https://claude.com/claude-code)