### PR TITLE
Route inspector and gate logs through the goverse logger

### DIFF
--- a/cmd/gate/main.go
+++ b/cmd/gate/main.go
@@ -2,14 +2,16 @@ package main
 
 import (
 	"context"
-	"log"
 	"os"
 	"os/signal"
 	"syscall"
 
 	"github.com/xiaonanln/goverse/cmd/gate/gateconfig"
 	"github.com/xiaonanln/goverse/gate/gateserver"
+	"github.com/xiaonanln/goverse/util/logger"
 )
+
+var log = logger.NewLogger("Gate")
 
 func main() {
 	// Get gate server configuration from flags and/or config file
@@ -33,7 +35,7 @@ func main() {
 		log.Fatalf("Failed to start gate server: %v", err)
 	}
 
-	log.Println("Gate server started")
+	log.Infof("Gate server started")
 
 	// Handle signals for graceful shutdown
 	sigChan := make(chan os.Signal, 1)
@@ -41,12 +43,12 @@ func main() {
 
 	// Wait for shutdown signal
 	<-sigChan
-	log.Println("Received shutdown signal")
+	log.Infof("Received shutdown signal")
 
 	// Stop the gate server
 	if err := gateserver.Stop(); err != nil {
-		log.Printf("Error stopping gate: %v", err)
+		log.Errorf("Error stopping gate: %v", err)
 	}
 
-	log.Println("Gate stopped")
+	log.Infof("Gate stopped")
 }

--- a/cmd/inspector/inspector/inspector.go
+++ b/cmd/inspector/inspector/inspector.go
@@ -4,16 +4,18 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log"
 	"sync"
 	"time"
 
 	"github.com/xiaonanln/goverse/cmd/inspector/graph"
 	"github.com/xiaonanln/goverse/cmd/inspector/models"
 	inspector_pb "github.com/xiaonanln/goverse/cmd/inspector/proto"
+	"github.com/xiaonanln/goverse/util/logger"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
+
+var log = logger.NewLogger("Inspector")
 
 type GoverseNode = models.GoverseNode
 type GoverseObject = models.GoverseObject
@@ -229,7 +231,7 @@ func (i *Inspector) RemoveObject(ctx context.Context, req *inspector_pb.RemoveOb
 	}
 
 	i.pg.RemoveObject(objectID)
-	log.Printf("Object removed: object_id=%s, node=%s", objectID, nodeAddress)
+	log.Debugf("Object removed: object_id=%s, node=%s", objectID, nodeAddress)
 	return &inspector_pb.Empty{}, nil
 }
 
@@ -237,7 +239,7 @@ func (i *Inspector) RemoveObject(ctx context.Context, req *inspector_pb.RemoveOb
 func (i *Inspector) RegisterNode(ctx context.Context, req *inspector_pb.RegisterNodeRequest) (*inspector_pb.RegisterNodeResponse, error) {
 	addr := req.GetAdvertiseAddress()
 	if addr == "" {
-		log.Println("RegisterNode called with empty advertise address")
+		log.Warnf("RegisterNode called with empty advertise address")
 		return nil, errors.New("advertise address cannot be empty")
 	}
 
@@ -282,7 +284,7 @@ func (i *Inspector) RegisterNode(ctx context.Context, req *inspector_pb.Register
 		i.pg.AddOrUpdateObject(obj)
 	}
 
-	log.Printf("Node registered: advertise_addr=%s, connected_nodes=%v, registered_gates=%v", addr, req.GetConnectedNodes(), req.GetRegisteredGates())
+	log.Debugf("Node registered: advertise_addr=%s, connected_nodes=%v, registered_gates=%v", addr, req.GetConnectedNodes(), req.GetRegisteredGates())
 	return &inspector_pb.RegisterNodeResponse{}, nil
 }
 
@@ -291,7 +293,7 @@ func (i *Inspector) UnregisterNode(ctx context.Context, req *inspector_pb.Unregi
 	addr := req.GetAdvertiseAddress()
 
 	i.pg.RemoveNode(addr)
-	log.Printf("Node unregistered: advertise_addr=%s", addr)
+	log.Debugf("Node unregistered: advertise_addr=%s", addr)
 	return &inspector_pb.Empty{}, nil
 }
 
@@ -299,7 +301,7 @@ func (i *Inspector) UnregisterNode(ctx context.Context, req *inspector_pb.Unregi
 func (i *Inspector) RegisterGate(ctx context.Context, req *inspector_pb.RegisterGateRequest) (*inspector_pb.RegisterGateResponse, error) {
 	addr := req.GetAdvertiseAddress()
 	if addr == "" {
-		log.Println("RegisterGate called with empty advertise address")
+		log.Warnf("RegisterGate called with empty advertise address")
 		return nil, errors.New("advertise address cannot be empty")
 	}
 
@@ -315,7 +317,7 @@ func (i *Inspector) RegisterGate(ctx context.Context, req *inspector_pb.Register
 	}
 	i.pg.AddOrUpdateGate(gate)
 
-	log.Printf("Gate registered: advertise_addr=%s, connected_nodes=%v, clients=%d", addr, req.GetConnectedNodes(), req.GetClients())
+	log.Debugf("Gate registered: advertise_addr=%s, connected_nodes=%v, clients=%d", addr, req.GetConnectedNodes(), req.GetClients())
 	return &inspector_pb.RegisterGateResponse{}, nil
 }
 
@@ -324,7 +326,7 @@ func (i *Inspector) UnregisterGate(ctx context.Context, req *inspector_pb.Unregi
 	addr := req.GetAdvertiseAddress()
 
 	i.pg.RemoveGate(addr)
-	log.Printf("Gate unregistered: advertise_addr=%s", addr)
+	log.Debugf("Gate unregistered: advertise_addr=%s", addr)
 	return &inspector_pb.Empty{}, nil
 }
 
@@ -333,7 +335,7 @@ func (i *Inspector) UnregisterGate(ctx context.Context, req *inspector_pb.Unregi
 func (i *Inspector) UpdateConnectedNodes(ctx context.Context, req *inspector_pb.UpdateConnectedNodesRequest) (*inspector_pb.Empty, error) {
 	addr := req.GetAdvertiseAddress()
 	if addr == "" {
-		log.Println("UpdateConnectedNodes called with empty advertise address")
+		log.Warnf("UpdateConnectedNodes called with empty advertise address")
 		return nil, errors.New("advertise address cannot be empty")
 	}
 
@@ -346,13 +348,13 @@ func (i *Inspector) UpdateConnectedNodes(ctx context.Context, req *inspector_pb.
 	// Try to update as node first, then as gate
 	if i.pg.IsNodeRegistered(addr) {
 		i.pg.UpdateNodeConnectedNodes(addr, connectedNodes)
-		log.Printf("Node connected_nodes updated: advertise_addr=%s, connected_nodes=%v", addr, connectedNodes)
+		log.Debugf("Node connected_nodes updated: advertise_addr=%s, connected_nodes=%v", addr, connectedNodes)
 	} else if i.pg.IsGateRegistered(addr) {
 		i.pg.UpdateGateConnectedNodes(addr, connectedNodes)
-		log.Printf("Gate connected_nodes updated: advertise_addr=%s, connected_nodes=%v", addr, connectedNodes)
+		log.Debugf("Gate connected_nodes updated: advertise_addr=%s, connected_nodes=%v", addr, connectedNodes)
 	} else {
 		// Neither node nor gate is registered, log but don't error
-		log.Printf("UpdateConnectedNodes: no node or gate registered with address %s", addr)
+		log.Warnf("UpdateConnectedNodes: no node or gate registered with address %s", addr)
 	}
 
 	return &inspector_pb.Empty{}, nil
@@ -362,7 +364,7 @@ func (i *Inspector) UpdateConnectedNodes(ctx context.Context, req *inspector_pb.
 func (i *Inspector) UpdateGateClients(ctx context.Context, req *inspector_pb.UpdateGateClientsRequest) (*inspector_pb.Empty, error) {
 	addr := req.GetAdvertiseAddress()
 	if addr == "" {
-		log.Println("UpdateGateClients called with empty advertise address")
+		log.Warnf("UpdateGateClients called with empty advertise address")
 		return nil, errors.New("advertise address cannot be empty")
 	}
 
@@ -371,9 +373,9 @@ func (i *Inspector) UpdateGateClients(ctx context.Context, req *inspector_pb.Upd
 	// Update gate clients in the graph
 	if i.pg.IsGateRegistered(addr) {
 		i.pg.UpdateGateClients(addr, clients)
-		log.Printf("Gate clients updated: advertise_addr=%s, clients=%d", addr, clients)
+		log.Debugf("Gate clients updated: advertise_addr=%s, clients=%d", addr, clients)
 	} else {
-		log.Printf("UpdateGateClients: no gate registered with address %s", addr)
+		log.Warnf("UpdateGateClients: no gate registered with address %s", addr)
 	}
 
 	return &inspector_pb.Empty{}, nil
@@ -383,7 +385,7 @@ func (i *Inspector) UpdateGateClients(ctx context.Context, req *inspector_pb.Upd
 func (i *Inspector) UpdateRegisteredGates(ctx context.Context, req *inspector_pb.UpdateRegisteredGatesRequest) (*inspector_pb.Empty, error) {
 	addr := req.GetAdvertiseAddress()
 	if addr == "" {
-		log.Println("UpdateRegisteredGates called with empty advertise address")
+		log.Warnf("UpdateRegisteredGates called with empty advertise address")
 		return nil, errors.New("advertise address cannot be empty")
 	}
 
@@ -395,10 +397,10 @@ func (i *Inspector) UpdateRegisteredGates(ctx context.Context, req *inspector_pb
 	// Only nodes can have registered gates
 	if i.pg.IsNodeRegistered(addr) {
 		i.pg.UpdateNodeRegisteredGates(addr, registeredGates)
-		log.Printf("Node registered_gates updated: advertise_addr=%s, registered_gates=%v", addr, registeredGates)
+		log.Debugf("Node registered_gates updated: advertise_addr=%s, registered_gates=%v", addr, registeredGates)
 	} else {
 		// Node is not registered, log but don't error
-		log.Printf("UpdateRegisteredGates: no node registered with address %s", addr)
+		log.Warnf("UpdateRegisteredGates: no node registered with address %s", addr)
 	}
 
 	return &inspector_pb.Empty{}, nil

--- a/cmd/inspector/inspectserver/inspectserver.go
+++ b/cmd/inspector/inspectserver/inspectserver.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"log"
 	"net"
 	"net/http"
 	"net/http/pprof"
@@ -24,7 +23,10 @@ import (
 	"github.com/xiaonanln/goverse/cmd/inspector/inspector"
 	"github.com/xiaonanln/goverse/cmd/inspector/models"
 	inspector_pb "github.com/xiaonanln/goverse/cmd/inspector/proto"
+	"github.com/xiaonanln/goverse/util/logger"
 )
+
+var log = logger.NewLogger("InspectorServer")
 
 type GoverseNode = models.GoverseNode
 type GoverseObject = models.GoverseObject
@@ -91,12 +93,12 @@ func New(pg *graph.GoverseGraph, cfg Config) *InspectorServer {
 	if cfg.EtcdAddr != "" {
 		mgr, err := etcdmanager.NewEtcdManager(cfg.EtcdAddr, cfg.EtcdPrefix)
 		if err != nil {
-			log.Printf("Failed to create etcd manager: %v", err)
+			log.Errorf("Failed to create etcd manager: %v", err)
 		} else if err := mgr.Connect(); err != nil {
-			log.Printf("Failed to connect to etcd: %v", err)
+			log.Errorf("Failed to connect to etcd: %v", err)
 		} else {
 			s.etcdManager = mgr
-			log.Printf("Connected to etcd at %s with prefix %s", cfg.EtcdAddr, cfg.EtcdPrefix)
+			log.Infof("Connected to etcd at %s with prefix %s", cfg.EtcdAddr, cfg.EtcdPrefix)
 
 			// Initialize ConsensusManager for watching cluster state
 			numShards := cfg.NumShards
@@ -116,15 +118,15 @@ func New(pg *graph.GoverseGraph, cfg Config) *InspectorServer {
 			initCtx, initCancel := context.WithTimeout(context.Background(), 30*time.Second)
 			if err := s.consensusManager.Initialize(initCtx); err != nil {
 				initCancel()
-				log.Panicf("Failed to initialize consensus manager: %v", err)
+				log.Fatalf("Failed to initialize consensus manager: %v", err)
 			}
 			initCancel()
 
 			// Start watching with a long-lived context (will be cancelled on shutdown)
 			if err := s.consensusManager.StartWatch(context.Background()); err != nil {
-				log.Panicf("Failed to start consensus manager watch: %v", err)
+				log.Fatalf("Failed to start consensus manager watch: %v", err)
 			}
-			log.Printf("ConsensusManager initialized and watching cluster state")
+			log.Infof("ConsensusManager initialized and watching cluster state")
 
 			// Register as listener to receive shard state changes
 			s.consensusManager.AddListener(s)
@@ -145,7 +147,7 @@ func (s *InspectorServer) GetConsensusManager() *consensusmanager.ConsensusManag
 // OnClusterStateChanged implements consensusmanager.StateChangeListener
 // This is called when shard mappings change in etcd
 func (s *InspectorServer) OnClusterStateChanged() {
-	log.Printf("Cluster state changed, broadcasting shard_update to SSE clients")
+	log.Debugf("Cluster state changed, broadcasting shard_update to SSE clients")
 	s.broadcastShardUpdate()
 }
 
@@ -164,7 +166,7 @@ func (s *InspectorServer) OnGraphEvent(event graph.GraphEvent) {
 		case <-client.done:
 		default:
 			// Channel full, log and skip this event for this client
-			log.Printf("Event dropped for SSE client %s: channel full", client.id)
+			log.Warnf("Event dropped for SSE client %s: channel full", client.id)
 		}
 	}
 }
@@ -251,7 +253,7 @@ func (s *InspectorServer) handleEventsStream(w http.ResponseWriter, r *http.Requ
 	s.sseClients[clientID] = client
 	s.sseClientsMu.Unlock()
 
-	log.Printf("SSE client connected: %s", clientID)
+	log.Infof("SSE client connected: %s", clientID)
 
 	// Cleanup on disconnect
 	defer func() {
@@ -259,7 +261,7 @@ func (s *InspectorServer) handleEventsStream(w http.ResponseWriter, r *http.Requ
 		s.sseClientsMu.Lock()
 		delete(s.sseClients, clientID)
 		s.sseClientsMu.Unlock()
-		log.Printf("SSE client disconnected: %s", clientID)
+		log.Infof("SSE client disconnected: %s", clientID)
 	}()
 
 	// Send initial full state
@@ -278,7 +280,7 @@ func (s *InspectorServer) handleEventsStream(w http.ResponseWriter, r *http.Requ
 		GoverseObjects: objects,
 	}
 	if err := s.writeSSEEvent(w, flusher, "initial", initialData); err != nil {
-		log.Printf("Failed to send initial state to SSE client %s: %v", clientID, err)
+		log.Errorf("Failed to send initial state to SSE client %s: %v", clientID, err)
 		return
 	}
 
@@ -297,13 +299,13 @@ func (s *InspectorServer) handleEventsStream(w http.ResponseWriter, r *http.Requ
 		case <-heartbeatTicker.C:
 			// Send heartbeat to keep connection alive
 			if err := s.writeSSEEvent(w, flusher, "heartbeat", struct{}{}); err != nil {
-				log.Printf("Failed to send heartbeat to SSE client %s: %v", clientID, err)
+				log.Errorf("Failed to send heartbeat to SSE client %s: %v", clientID, err)
 				return
 			}
 		case event := <-client.eventChan:
 			eventType := string(event.Type)
 			if err := s.writeSSEEvent(w, flusher, eventType, event); err != nil {
-				log.Printf("Failed to send event to SSE client %s: %v", clientID, err)
+				log.Errorf("Failed to send event to SSE client %s: %v", clientID, err)
 				return
 			}
 		}
@@ -336,24 +338,24 @@ func (s *InspectorServer) ServeHTTP(done chan<- struct{}) error {
 		Handler:           handler,
 		ReadHeaderTimeout: 5 * time.Second,
 	}
-	log.Printf("HTTP on %s (serving %s)", s.httpAddr, filepath.Join(".", s.staticDir))
+	log.Infof("HTTP on %s (serving %s)", s.httpAddr, filepath.Join(".", s.staticDir))
 
 	// Handle graceful shutdown
 	go func() {
 		<-s.shutdownChan
-		log.Println("Shutting down HTTP server...")
+		log.Infof("Shutting down HTTP server...")
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
 		if err := s.httpServer.Shutdown(ctx); err != nil {
-			log.Printf("HTTP server shutdown error: %v", err)
+			log.Errorf("HTTP server shutdown error: %v", err)
 		}
 	}()
 
 	go func() {
 		if err := s.httpServer.ListenAndServe(); err != nil && err != http.ErrServerClosed {
-			log.Printf("HTTP server error: %v", err)
+			log.Errorf("HTTP server error: %v", err)
 		}
-		log.Println("HTTP server stopped")
+		log.Infof("HTTP server stopped")
 		done <- struct{}{}
 	}()
 
@@ -369,20 +371,20 @@ func (s *InspectorServer) ServeGRPC(done chan<- struct{}) error {
 	s.grpcServer = grpc.NewServer()
 	inspector_pb.RegisterInspectorServiceServer(s.grpcServer, inspector.New(s.pg))
 	reflection.Register(s.grpcServer)
-	log.Printf("gRPC on %s", s.grpcAddr)
+	log.Infof("gRPC on %s", s.grpcAddr)
 
 	// Handle graceful shutdown
 	go func() {
 		<-s.shutdownChan
-		log.Println("Shutting down gRPC server...")
+		log.Infof("Shutting down gRPC server...")
 		s.grpcServer.GracefulStop()
 	}()
 
 	go func() {
 		if err := s.grpcServer.Serve(l); err != nil {
-			log.Printf("gRPC server error: %v", err)
+			log.Errorf("gRPC server error: %v", err)
 		}
-		log.Println("gRPC server stopped")
+		log.Infof("gRPC server stopped")
 		done <- struct{}{}
 	}()
 
@@ -489,7 +491,7 @@ func (s *InspectorServer) handleShardMove(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	log.Printf("Received shard move request: shard_id=%d, target_node=%s", req.ShardID, req.TargetNode)
+	log.Infof("Received shard move request: shard_id=%d, target_node=%s", req.ShardID, req.TargetNode)
 
 	// Validate shard ID (shards are 0-indexed and range from 0 to numShards-1)
 	if req.ShardID < 0 || req.ShardID >= s.consensusManager.GetNumShards() {
@@ -532,7 +534,7 @@ func (s *InspectorServer) handleShardMove(w http.ResponseWriter, r *http.Request
 	// Store the updated shard mapping
 	successCount, err := s.consensusManager.StoreShardMapping(ctx, updateShards)
 	if err != nil {
-		log.Printf("Failed to move shard %d to node %s: %v", req.ShardID, req.TargetNode, err)
+		log.Errorf("Failed to move shard %d to node %s: %v", req.ShardID, req.TargetNode, err)
 		http.Error(w, fmt.Sprintf("Failed to move shard: %v", err), http.StatusInternalServerError)
 		return
 	}
@@ -542,7 +544,7 @@ func (s *InspectorServer) handleShardMove(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	log.Printf("Successfully updated shard %d target to %s (current=%s)", req.ShardID, req.TargetNode, currentShardInfo.CurrentNode)
+	log.Infof("Successfully updated shard %d target to %s (current=%s)", req.ShardID, req.TargetNode, currentShardInfo.CurrentNode)
 
 	// Broadcast shard update event to all SSE clients
 	s.broadcastShardUpdate()
@@ -556,7 +558,7 @@ func (s *InspectorServer) handleShardMove(w http.ResponseWriter, r *http.Request
 		"message":     fmt.Sprintf("Shard %d target updated to %s", req.ShardID, req.TargetNode),
 	}
 	if err := json.NewEncoder(w).Encode(response); err != nil {
-		log.Printf("Failed to encode response: %v", err)
+		log.Errorf("Failed to encode response: %v", err)
 	}
 }
 
@@ -634,7 +636,7 @@ func (s *InspectorServer) handleShardPin(w http.ResponseWriter, r *http.Request)
 	if req.Pinned {
 		action = "pinned"
 	}
-	log.Printf("Shard %d %s successfully", req.ShardID, action)
+	log.Infof("Shard %d %s successfully", req.ShardID, action)
 
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(map[string]interface{}{
@@ -696,16 +698,16 @@ func (s *InspectorServer) broadcastShardUpdate() {
 	}
 	s.sseClientsMu.RUnlock()
 
-	log.Printf("Broadcasting shard_update to %d SSE clients", len(clients))
+	log.Debugf("Broadcasting shard_update to %d SSE clients", len(clients))
 
 	for _, client := range clients {
 		select {
 		case client.eventChan <- event:
-			log.Printf("Sent shard_update to SSE client %s", client.id)
+			log.Debugf("Sent shard_update to SSE client %s", client.id)
 		case <-client.done:
-			log.Printf("Client %s already disconnected", client.id)
+			log.Debugf("Client %s already disconnected", client.id)
 		default:
-			log.Printf("Event dropped for SSE client %s: channel full", client.id)
+			log.Warnf("Event dropped for SSE client %s: channel full", client.id)
 		}
 	}
 }

--- a/cmd/inspector/main.go
+++ b/cmd/inspector/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"log"
 	"os"
 	"os/signal"
 	"syscall"
@@ -10,7 +9,10 @@ import (
 	"github.com/xiaonanln/goverse/cmd/inspector/graph"
 	"github.com/xiaonanln/goverse/cmd/inspector/inspectorconfig"
 	"github.com/xiaonanln/goverse/cmd/inspector/inspectserver"
+	"github.com/xiaonanln/goverse/util/logger"
 )
+
+var log = logger.NewLogger("Inspector")
 
 func main() {
 	// Load configuration
@@ -40,7 +42,7 @@ func main() {
 
 	// Wait for shutdown signal
 	<-sigChan
-	log.Println("Received shutdown signal")
+	log.Infof("Received shutdown signal")
 	server.Shutdown()
 
 	// Wait for both servers to stop with timeout
@@ -51,10 +53,10 @@ func main() {
 		case <-serversDone:
 			serversShutdown++
 		case <-timeout:
-			log.Println("Timeout waiting for servers to shutdown")
+			log.Warnf("Timeout waiting for servers to shutdown")
 			return
 		}
 	}
 
-	log.Println("Inspector stopped")
+	log.Infof("Inspector stopped")
 }


### PR DESCRIPTION
## Summary
- The inspector, inspectserver, `cmd/gate/main.go` and `cmd/inspector/main.go` were using stdlib `log.Printf`, which bypasses the goverse logger's level filter.
- In stress runs the per-event \`Node connected_nodes updated\`, \`Node registered_gates updated\` and SSE broadcast lines dominated stdout regardless of the configured WARN default.
- Switched each file to a package-level goverse logger and demoted the high-frequency per-event lines to Debug. Errors stay at Error, validation guards become Warn, one-shot startup/shutdown lines stay at Info. \`log.Panicf\` in \`InspectorServer.New\` becomes \`logger.Fatalf\` (exits 1 after structured logging).

## Test plan
- [x] \`go build ./...\`
- [x] \`go vet ./...\`
- [x] \`go test ./cmd/inspector/... ./cmd/gate/... ./gate/...\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)