### PR TITLE
Demote gate stream close log to Warn

### DIFF
--- a/gate/gate.go
+++ b/gate/gate.go
@@ -325,7 +325,7 @@ func (g *Gate) registerWithNode(ctx context.Context, nodeAddr string, client gov
 
 		msg, err := stream.Recv()
 		if err != nil {
-			g.logger.Errorf("Stream from node %s closed: %v", nodeAddr, err)
+			g.logger.Warnf("Stream from node %s closed: %v", nodeAddr, err)
 			return
 		}
 		g.handleGateMessage(nodeAddr, msg)


### PR DESCRIPTION
## Summary
- \`Gate.recv\` used to log every \`stream.Recv\` error at Error level. During shutdown the gate cancels its own recv context, which closes the stream with \`codes.Canceled\` — expected teardown, not a failure.
- In stress runs this produced ~70 ERROR lines per shutdown (7 gates × 10 node streams).
- Demote to Warn so the message still shows at the default level but no longer reads like a real gRPC error.

## Test plan
- [x] \`go build ./...\`
- [x] \`go vet ./gate/...\`
- [x] \`go test ./gate/...\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)