### PR TITLE
Demote no-auto-load cluster log from Warn to Debug

### DIFF
--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -1591,7 +1591,7 @@ func (c *Cluster) loadAutoLoadObjects(ctx context.Context) {
 	}
 
 	if len(c.config.AutoLoadObjects) == 0 {
-		c.logger.Warnf("%s - No auto-load objects configured, skipping", c)
+		c.logger.Debugf("%s - No auto-load objects configured, skipping", c)
 		return
 	}
 


### PR DESCRIPTION
## Summary
- \`cluster/cluster.go:1594\` logged Warn every time a cluster started without an \`auto_load_objects\` config block. That's the norm — counter, chat, tictactoe, wallet all omit it; only sharding_demo uses the feature. Warn implies "operator should look at this," which isn't true for a routine configuration choice.
- Demoted to Debug.

## Test plan
- [x] \`go build ./...\`
- [x] \`go vet ./cluster/...\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)