### PR TITLE
CHANGELOG: cover work since the 2026-04-19 draft

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,20 +36,9 @@ and trust that basic failure modes are handled correctly.
 - **Docs**: end-to-end "5-Minute Tour" in `docs/GET_STARTED.md`; full
   getting-started guide, API reference, HTTP gate spec, and design docs.
 - **Samples**: `counter`, `tictactoe`, `chat`, `sharding_demo`, and
-  `wallet` (demonstrates exactly-once reliable calls end-to-end; its
-  stress test injects mid-flight timeout aborts and validates per-wallet
-  conservation under ~1.7k calls/sec with 100 clients).
-- **Python client**: `reliable_call_object` / `reliable_call_object_any`
-  wrappers, `generate_call_id` helper matching the Go client's 24-char
-  base64url format, and a `ReliableCallError` exception that surfaces the
-  server-reported status for retry decisions.
-- **SSE broadcast efficiency**: Inspector pre-formats graph events once
-  and fans the bytes out to all subscribers instead of re-marshalling
-  per client.
-- **Operator-friendly log levels**: per-RPC chatter demoted to Debug;
-  inspector, gate, and Postgres output routed through the goverse logger;
-  expected shutdown paths (gate stream close, cluster "no auto-load
-  configured") no longer surface as Warn.
+  `wallet` (end-to-end reliable-call demo with a stress test that
+  injects mid-flight timeout aborts and verifies per-wallet balance
+  conservation).
 
 ### Known Issues (deferred to v0.2.0)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to GoVerse are documented in this file.
 
-## [0.1.0] — 2026-04-19
+## [0.1.0] — 2026-04-24
 
 First tagged release. GoVerse is a distributed object runtime for Go that
 implements the virtual actor model with etcd-based placement and 8192-shard
@@ -35,7 +35,21 @@ and trust that basic failure modes are handled correctly.
   and Postgres.
 - **Docs**: end-to-end "5-Minute Tour" in `docs/GET_STARTED.md`; full
   getting-started guide, API reference, HTTP gate spec, and design docs.
-- **Samples**: `counter`, `tictactoe`, `chat`, `sharding_demo`.
+- **Samples**: `counter`, `tictactoe`, `chat`, `sharding_demo`, and
+  `wallet` (demonstrates exactly-once reliable calls end-to-end; its
+  stress test injects mid-flight timeout aborts and validates per-wallet
+  conservation under ~1.7k calls/sec with 100 clients).
+- **Python client**: `reliable_call_object` / `reliable_call_object_any`
+  wrappers, `generate_call_id` helper matching the Go client's 24-char
+  base64url format, and a `ReliableCallError` exception that surfaces the
+  server-reported status for retry decisions.
+- **SSE broadcast efficiency**: Inspector pre-formats graph events once
+  and fans the bytes out to all subscribers instead of re-marshalling
+  per client.
+- **Operator-friendly log levels**: per-RPC chatter demoted to Debug;
+  inspector, gate, and Postgres output routed through the goverse logger;
+  expected shutdown paths (gate stream close, cluster "no auto-load
+  configured") no longer surface as Warn.
 
 ### Known Issues (deferred to v0.2.0)
 


### PR DESCRIPTION
## Summary
- The v0.1.0 CHANGELOG entry on main was written on 2026-04-19, before several notable additions merged. Refresh it so the release notes actually describe what v0.1.0 will ship.
- Updated: date bumped to 2026-04-24; \`Samples\` bullet now includes \`wallet\`; added \`Python client\`, \`SSE broadcast efficiency\`, and \`Operator-friendly log levels\` bullets.
- No code changes.

## Test plan
- [x] Read it — all additions correspond to already-merged PRs (#525–#534).

🤖 Generated with [Claude Code](https://claude.com/claude-code)