### PR TITLE
Share the sample server subprocess wrapper across DemoServer and WalletServer

### DIFF
--- a/samples/sharding_demo/DemoServer.py
+++ b/samples/sharding_demo/DemoServer.py
@@ -1,174 +1,32 @@
 #!/usr/bin/env python3
-"""DemoServer helper for managing the demo server process."""
-import os
-import subprocess
-import signal
+"""DemoServer helper — thin wrapper around the shared ServerProcess base."""
 import sys
-import time
 from pathlib import Path
 
-# Repo root (samples/sharding_demo/DemoServer.py -> repo root)
+# samples/sharding_demo/DemoServer.py -> repo root
 REPO_ROOT = Path(__file__).parent.parent.parent.resolve()
 sys.path.insert(0, str(REPO_ROOT))
-# Expose the samples directory for shared modules like BinaryHelper
 SAMPLES_DIR = REPO_ROOT / 'tests' / 'samples'
 sys.path.insert(0, str(SAMPLES_DIR))
 
-from BinaryHelper import BinaryHelper
-from PortHelper import get_free_port
+from ServerProcess import ServerProcess, ServerStopTimeout
+
+# Back-compat alias: existing callers import DemoServerStopTimeout.
+DemoServerStopTimeout = ServerStopTimeout
 
 
-class DemoServerStopTimeout(RuntimeError):
-    """Raised when a demo server fails to exit within the SIGTERM grace.
+class DemoServer(ServerProcess):
+    """Manages a Goverse demo server (samples/sharding_demo) subprocess."""
 
-    Hanging on SIGTERM means the node is stuck somewhere in shutdown
-    (e.g. blocked persistence flush, deadlocked goroutine) — a real bug we
-    want to surface loudly instead of papering over with SIGKILL.
-    """
-
-
-class DemoServer:
-    """Manages a Goverse demo server process."""
-    
-    process: subprocess.Popen | None
-    
-    def __init__(self, server_index=0, binary_path=None, config_file=None, 
+    def __init__(self, server_index=0, binary_path=None, config_file=None,
                  node_id=None, build_if_needed=True):
-        """Initialize and optionally build the demo server.
-        
-        Args:
-            server_index: Index of this server (for naming)
-            binary_path: Path to demo server binary (defaults to /tmp/demo_server)
-            config_file: Path to YAML config file (required)
-            node_id: Node ID from config file (required)
-            build_if_needed: Whether to build the binary if it doesn't exist
-        """
-        self.server_index = server_index
-        self.binary_path = binary_path if binary_path is not None else '/tmp/demo_server'
-        self.config_file = config_file
-        self.node_id = node_id
-        
-        # Config file and node_id are required
-        if not config_file or not node_id:
-            raise ValueError("config_file and node_id are required")
-        
-        # Parse ports from config file
-        import yaml
-        with open(config_file, 'r') as f:
-            config = yaml.safe_load(f)
-        
-        # Find the node configuration by node_id
-        node_config = None
-        for node in config.get('nodes', []):
-            if node.get('id') == node_id:
-                node_config = node
-                break
-        if not node_config:
-            raise ValueError(f"Node ID '{node_id}' not found in config file")
-        
-        # Parse listen port from grpc_addr
-        grpc_addr = node_config.get('grpc_addr', '0.0.0.0:9211')
-        self.listen_port = int(grpc_addr.split(':')[1]) if ':' in grpc_addr else 9211
-        
-        self.process = None
-        self.name = f"Demo Server {server_index + 1}"
-        
-        # Build binary if needed
-        if build_if_needed and not os.path.exists(self.binary_path):
-            if not BinaryHelper.build_binary('./samples/sharding_demo/', self.binary_path, 'demo server'):
-                raise RuntimeError(f"Failed to build demo server binary at {self.binary_path}")
-    
-    def start(self) -> None:
-        """Start the demo server process."""
-        if self.process is not None:
-            print(f"⚠️  {self.name} is already running")
-            return
-
-        # Build command line arguments (always use config file)
-        cmd = [self.binary_path, '--config', self.config_file, '--node-id', self.node_id]
-
-        # Check if coverage is enabled
-        cov_dir = os.environ.get('GOCOVERDIR', '').strip()
-        env = os.environ.copy()
-        if cov_dir:
-            # Create server-specific coverage directory
-            server_cov_dir = os.path.join(cov_dir, f'demo_server_{self.server_index}')
-            os.makedirs(server_cov_dir, exist_ok=True)
-            env['GOCOVERDIR'] = server_cov_dir
-
-        # Start process
-        print(f"Starting {self.name} (node_id: {self.node_id}, port: {self.listen_port})...")
-        self.process = subprocess.Popen(
-            cmd,
-            stdout=None,
-            stderr=None,
-            env=env,
-            text=True,
-            bufsize=1
+        super().__init__(
+            kind="Demo",
+            binary_path=binary_path or '/tmp/demo_server',
+            build_source_path='./samples/sharding_demo/',
+            coverage_prefix='demo_server',
+            server_index=server_index,
+            config_file=config_file,
+            node_id=node_id,
+            build_if_needed=build_if_needed,
         )
-        
-        # Give it a moment to start
-        time.sleep(0.5)
-        
-        # Check if process is still running
-        if self.process.poll() is not None:
-            stdout, _ = self.process.communicate()
-            raise RuntimeError(f"{self.name} failed to start. Output:\n{stdout}")
-    
-    def wait_for_ready(self, timeout: float = 30) -> bool:
-        """Wait for the demo server to be ready.
-        
-        Args:
-            timeout: Maximum time to wait in seconds
-            
-        Returns:
-            True if ready, False if timeout
-        """
-        print(f"Waiting for {self.name} to be ready...")
-        start = time.time()
-        
-        # The demo server is ready when it starts handling requests
-        # For now, just wait a bit for it to initialize
-        while time.time() - start < timeout:
-            if self.process and self.process.poll() is not None:
-                print(f"❌ {self.name} terminated unexpectedly")
-                return False
-            time.sleep(0.5)
-            # Check if enough time has passed for initialization
-            if time.time() - start > 1:
-                print(f"✅ {self.name} is ready")
-                return True
-        
-        print(f"⚠️  {self.name} wait timeout")
-        return False
-    
-    def close(self) -> None:
-        """Stop the demo server process."""
-        if self.process is None:
-            return
-
-        print(f"Stopping {self.name}...")
-
-        # SIGTERM grace must cover Node.Stop() persisting every in-memory
-        # object to Postgres. gRPC shutdown itself is near-instant (server
-        # hard-stops the listener instead of draining), so the dominant cost
-        # is proportional to the number of dirty objects. 20s is a
-        # comfortable ceiling for the stress demo workload.
-        #
-        # If SIGTERM doesn't return within the grace, we deliberately do NOT
-        # follow up with SIGKILL: a hang in graceful shutdown is a real bug
-        # (stuck persistence, deadlocked goroutine, lost shutdown signal)
-        # and SIGKILL would mask it. Raise instead so the test fails loudly
-        # and the leaked process stays around as evidence.
-        try:
-            self.process.send_signal(signal.SIGTERM)
-            self.process.wait(timeout=20)
-        except subprocess.TimeoutExpired:
-            pid = self.process.pid
-            raise DemoServerStopTimeout(
-                f"{self.name} (pid={pid}) did not exit within 20s of SIGTERM; "
-                "investigate the hang before re-running"
-            )
-
-        self.process = None
-        print(f"✅ {self.name} stopped")

--- a/samples/wallet/WalletServer.py
+++ b/samples/wallet/WalletServer.py
@@ -1,122 +1,32 @@
 #!/usr/bin/env python3
-"""WalletServer helper for managing the wallet server process in tests."""
-import os
-import signal
-import subprocess
+"""WalletServer helper — thin wrapper around the shared ServerProcess base."""
 import sys
-import time
 from pathlib import Path
 
+# samples/wallet/WalletServer.py -> repo root
 REPO_ROOT = Path(__file__).parent.parent.parent.resolve()
 sys.path.insert(0, str(REPO_ROOT))
 SAMPLES_DIR = REPO_ROOT / 'tests' / 'samples'
 sys.path.insert(0, str(SAMPLES_DIR))
 
-from BinaryHelper import BinaryHelper
+from ServerProcess import ServerProcess, ServerStopTimeout
+
+# Back-compat alias: existing callers import WalletServerStopTimeout.
+WalletServerStopTimeout = ServerStopTimeout
 
 
-class WalletServerStopTimeout(RuntimeError):
-    """Raised when a wallet server fails to exit within the SIGTERM grace."""
-
-
-class WalletServer:
-    """Manages a Goverse wallet server process for the stress test."""
-
-    process: subprocess.Popen | None
+class WalletServer(ServerProcess):
+    """Manages a Goverse wallet server (samples/wallet) subprocess."""
 
     def __init__(self, server_index=0, binary_path=None, config_file=None,
                  node_id=None, build_if_needed=True):
-        self.server_index = server_index
-        self.binary_path = binary_path or '/tmp/wallet_server'
-        self.config_file = config_file
-        self.node_id = node_id
-
-        if not config_file or not node_id:
-            raise ValueError("config_file and node_id are required")
-
-        import yaml
-        with open(config_file, 'r') as f:
-            config = yaml.safe_load(f)
-
-        node_config = None
-        for node in config.get('nodes', []):
-            if node.get('id') == node_id:
-                node_config = node
-                break
-        if not node_config:
-            raise ValueError(f"Node ID '{node_id}' not found in config file")
-
-        grpc_addr = node_config.get('grpc_addr', '0.0.0.0:9311')
-        self.listen_port = int(grpc_addr.split(':')[1]) if ':' in grpc_addr else 9311
-
-        self.process = None
-        self.name = f"Wallet Server {server_index + 1}"
-
-        if build_if_needed and not os.path.exists(self.binary_path):
-            if not BinaryHelper.build_binary('./samples/wallet/server/', self.binary_path, 'wallet server'):
-                raise RuntimeError(f"Failed to build wallet server binary at {self.binary_path}")
-
-    def start(self) -> None:
-        if self.process is not None:
-            print(f"⚠️  {self.name} is already running")
-            return
-
-        cmd = [self.binary_path, '--config', self.config_file, '--node-id', self.node_id]
-
-        cov_dir = os.environ.get('GOCOVERDIR', '').strip()
-        env = os.environ.copy()
-        if cov_dir:
-            server_cov_dir = os.path.join(cov_dir, f'wallet_server_{self.server_index}')
-            os.makedirs(server_cov_dir, exist_ok=True)
-            env['GOCOVERDIR'] = server_cov_dir
-
-        print(f"Starting {self.name} (node_id: {self.node_id}, port: {self.listen_port})...")
-        self.process = subprocess.Popen(
-            cmd,
-            stdout=None,
-            stderr=None,
-            env=env,
-            text=True,
-            bufsize=1,
+        super().__init__(
+            kind="Wallet",
+            binary_path=binary_path or '/tmp/wallet_server',
+            build_source_path='./samples/wallet/server/',
+            coverage_prefix='wallet_server',
+            server_index=server_index,
+            config_file=config_file,
+            node_id=node_id,
+            build_if_needed=build_if_needed,
         )
-
-        time.sleep(0.5)
-
-        if self.process.poll() is not None:
-            stdout, _ = self.process.communicate()
-            raise RuntimeError(f"{self.name} failed to start. Output:\n{stdout}")
-
-    def wait_for_ready(self, timeout: float = 30) -> bool:
-        print(f"Waiting for {self.name} to be ready...")
-        start = time.time()
-        while time.time() - start < timeout:
-            if self.process and self.process.poll() is not None:
-                print(f"❌ {self.name} terminated unexpectedly")
-                return False
-            time.sleep(0.5)
-            if time.time() - start > 1:
-                print(f"✅ {self.name} is ready")
-                return True
-        print(f"⚠️  {self.name} wait timeout")
-        return False
-
-    def close(self) -> None:
-        # Hanging on SIGTERM indicates a real shutdown bug (stuck persistence
-        # flush, deadlocked goroutine). Do NOT SIGKILL on timeout — raise so
-        # the stuck process remains for post-mortem, matching DemoServer.
-        if self.process is None:
-            return
-
-        print(f"Stopping {self.name}...")
-        try:
-            self.process.send_signal(signal.SIGTERM)
-            self.process.wait(timeout=20)
-        except subprocess.TimeoutExpired:
-            pid = self.process.pid
-            raise WalletServerStopTimeout(
-                f"{self.name} (pid={pid}) did not exit within 20s of SIGTERM; "
-                "investigate the hang before re-running"
-            )
-
-        self.process = None
-        print(f"✅ {self.name} stopped")

--- a/tests/samples/ServerProcess.py
+++ b/tests/samples/ServerProcess.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python3
+"""Shared subprocess wrapper for sample server binaries used in stress tests.
+
+DemoServer (sharding_demo) and WalletServer (wallet) had identical lifecycle
+logic (config parsing, coverage-dir setup, SIGTERM-grace-then-raise). This
+module is the single source of truth; each sample's thin wrapper only has
+to provide its display name, binary path, and Go build-source path.
+"""
+import os
+import signal
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+# tests/samples/ServerProcess.py -> repo root
+REPO_ROOT = Path(__file__).parent.parent.parent.resolve()
+sys.path.insert(0, str(REPO_ROOT))
+SAMPLES_DIR = REPO_ROOT / 'tests' / 'samples'
+sys.path.insert(0, str(SAMPLES_DIR))
+
+from BinaryHelper import BinaryHelper
+
+
+class ServerStopTimeout(RuntimeError):
+    """Raised when a sample server fails to exit within the SIGTERM grace.
+
+    Hanging on SIGTERM means the node is stuck somewhere in shutdown
+    (blocked persistence flush, deadlocked goroutine, lost shutdown
+    signal) — a real bug we want to surface loudly. We deliberately do
+    NOT follow up with SIGKILL: that would mask the problem and the
+    leaked process is useful evidence.
+    """
+
+
+# Keep grace aligned with DemoServer's historical value: must cover
+# Node.Stop() persisting every in-memory object to Postgres. gRPC
+# shutdown itself is near-instant; the dominant cost is proportional
+# to the number of dirty objects.
+_STOP_GRACE_SECONDS = 20
+
+
+class ServerProcess:
+    """Base wrapper for a single sample server subprocess.
+
+    Subclasses should pass:
+      kind              - display name, e.g. "Wallet" or "Demo"
+      binary_path       - default binary location, e.g. '/tmp/wallet_server'
+      build_source_path - Go source path passed to BinaryHelper.build_binary,
+                          e.g. './samples/wallet/server/'
+      coverage_prefix   - per-server GOCOVERDIR subdir prefix, e.g. 'wallet_server'
+    """
+
+    process: subprocess.Popen | None
+
+    def __init__(self, kind, binary_path, build_source_path, coverage_prefix,
+                 server_index=0, config_file=None, node_id=None,
+                 build_if_needed=True):
+        if not config_file or not node_id:
+            raise ValueError("config_file and node_id are required")
+
+        self.kind = kind
+        self.binary_path = binary_path
+        self.build_source_path = build_source_path
+        self.coverage_prefix = coverage_prefix
+        self.server_index = server_index
+        self.config_file = config_file
+        self.node_id = node_id
+
+        import yaml
+        with open(config_file, 'r') as f:
+            config = yaml.safe_load(f)
+
+        node_config = None
+        for node in config.get('nodes', []):
+            if node.get('id') == node_id:
+                node_config = node
+                break
+        if not node_config:
+            raise ValueError(f"Node ID '{node_id}' not found in config file")
+
+        grpc_addr = node_config.get('grpc_addr', '')
+        self.listen_port = int(grpc_addr.split(':')[1]) if ':' in grpc_addr else 0
+
+        self.process = None
+        self.name = f"{kind} Server {server_index + 1}"
+
+        if build_if_needed and not os.path.exists(self.binary_path):
+            description = f"{kind.lower()} server"
+            if not BinaryHelper.build_binary(self.build_source_path, self.binary_path, description):
+                raise RuntimeError(f"Failed to build {description} binary at {self.binary_path}")
+
+    def start(self) -> None:
+        if self.process is not None:
+            print(f"⚠️  {self.name} is already running")
+            return
+
+        cmd = [self.binary_path, '--config', self.config_file, '--node-id', self.node_id]
+
+        env = os.environ.copy()
+        cov_dir = os.environ.get('GOCOVERDIR', '').strip()
+        if cov_dir:
+            server_cov_dir = os.path.join(cov_dir, f'{self.coverage_prefix}_{self.server_index}')
+            os.makedirs(server_cov_dir, exist_ok=True)
+            env['GOCOVERDIR'] = server_cov_dir
+
+        print(f"Starting {self.name} (node_id: {self.node_id}, port: {self.listen_port})...")
+        self.process = subprocess.Popen(
+            cmd,
+            stdout=None,
+            stderr=None,
+            env=env,
+            text=True,
+            bufsize=1,
+        )
+
+        time.sleep(0.5)
+
+        if self.process.poll() is not None:
+            stdout, _ = self.process.communicate()
+            raise RuntimeError(f"{self.name} failed to start. Output:\n{stdout}")
+
+    def wait_for_ready(self, timeout: float = 30) -> bool:
+        print(f"Waiting for {self.name} to be ready...")
+        start = time.time()
+        while time.time() - start < timeout:
+            if self.process and self.process.poll() is not None:
+                print(f"❌ {self.name} terminated unexpectedly")
+                return False
+            time.sleep(0.5)
+            if time.time() - start > 1:
+                print(f"✅ {self.name} is ready")
+                return True
+        print(f"⚠️  {self.name} wait timeout")
+        return False
+
+    def close(self) -> None:
+        if self.process is None:
+            return
+
+        print(f"Stopping {self.name}...")
+        try:
+            self.process.send_signal(signal.SIGTERM)
+            self.process.wait(timeout=_STOP_GRACE_SECONDS)
+        except subprocess.TimeoutExpired:
+            pid = self.process.pid
+            raise ServerStopTimeout(
+                f"{self.name} (pid={pid}) did not exit within {_STOP_GRACE_SECONDS}s of SIGTERM; "
+                "investigate the hang before re-running"
+            )
+
+        self.process = None
+        print(f"✅ {self.name} stopped")


### PR DESCRIPTION
## Summary
- \`samples/sharding_demo/DemoServer.py\` and \`samples/wallet/WalletServer.py\` were ~170-line near-duplicates (config parse, coverage-dir setup, SIGTERM-grace-then-raise lifecycle). Any future change had to be repeated in both and kept in sync by hand.
- Extracted the shared logic to \`tests/samples/ServerProcess.py\`. Each sample's helper is now a thin subclass that only customises the display name, default binary path, Go build source path, and coverage-dir prefix.
- Kept the existing exception names \`DemoServerStopTimeout\` and \`WalletServerStopTimeout\` as aliases, so stress tests and any external callers don't need to change.

Net −79 LOC across the three files.

## Test plan
- [x] Python import smoke test confirms both subclasses resolve, \`issubclass(..., ServerProcess)\` holds, and the legacy exception aliases still point at \`ServerStopTimeout\`.
- [ ] Full stress runs will exercise this in CI (\`demo-stress-test\`, \`demo-stress-test-churn\`, \`wallet-stress-test\`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)