### PR TITLE
Add bomberman sample (4/5): web UI + client_id propagation

### DIFF
--- a/samples/bomberman/proto/bomberman.proto
+++ b/samples/bomberman/proto/bomberman.proto
@@ -91,6 +91,14 @@ message AddPlayerRequest {
   string player_id = 1;
   int32 spawn_x = 2;
   int32 spawn_y = 3;
+  // client_id is the gate-assigned id of the connected browser /
+  // grpc client to push snapshots to. When the queue spawns a Match
+  // and calls AddPlayer it sets this so the player's original SSE
+  // subscription receives state, since the call's own context
+  // carries the queue object's client_id rather than the player's.
+  // For direct AddPlayer calls from a client, leaving this empty
+  // and relying on goverseapi.CallerClientID(ctx) is also fine.
+  string client_id = 4;
 }
 
 message AddPlayerResponse {
@@ -164,6 +172,12 @@ message PlayerData {
 
 message JoinQueueRequest {
   string player_id = 1;
+  // client_id may be set explicitly by HTTP/SSE clients that learned
+  // their gate-assigned id from the SSE "register" event. If empty,
+  // the queue falls back to goverseapi.CallerClientID(ctx) — which
+  // works for streaming gRPC clients but is empty for plain HTTP
+  // POSTs.
+  string client_id = 2;
 }
 
 message JoinQueueResponse {

--- a/samples/bomberman/server/match.go
+++ b/samples/bomberman/server/match.go
@@ -247,13 +247,18 @@ func (m *Match) broadcast(clientIDs []string, snap *pb.MatchSnapshot) {
 
 // AddPlayer places a fresh player on the grid. The Match must still
 // be in LOBBY status; spawn coordinates outside the grid or onto a
-// non-empty cell are rejected. The caller's client id (taken from the
-// request context) is recorded so subsequent snapshots are pushed to
-// it.
+// non-empty cell are rejected. The recorded client_id (used as the
+// snapshot push target) is taken from req.ClientId when set —
+// MatchmakingQueue uses this to forward the original player's gate
+// id — and falls back to goverseapi.CallerClientID(ctx) for direct
+// client invocations.
 func (m *Match) AddPlayer(ctx context.Context, req *pb.AddPlayerRequest) (*pb.AddPlayerResponse, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	clientID := goverseapi.CallerClientID(ctx)
+	clientID := req.ClientId
+	if clientID == "" {
+		clientID = goverseapi.CallerClientID(ctx)
+	}
 	if err := m.state.AddPlayer(req.PlayerId, clientID, int(req.SpawnX), int(req.SpawnY)); err != nil {
 		return &pb.AddPlayerResponse{Ok: false, Reason: err.Error()}, nil
 	}

--- a/samples/bomberman/server/matchmaking_queue.go
+++ b/samples/bomberman/server/matchmaking_queue.go
@@ -91,13 +91,19 @@ func (q *MatchmakingQueue) Stop() {
 
 // JoinQueue appends a player to the FIFO. Idempotent: a player already
 // queued gets ok=true with their existing position, not a duplicate
-// entry. The connecting client_id is captured from ctx so the spawned
-// match knows where to push snapshots.
+// entry. The connecting client_id (used by the spawned Match for
+// snapshot push routing) is taken from req.ClientId when set —
+// browsers learn their id from the SSE register event and pass it
+// here — and falls back to goverseapi.CallerClientID(ctx) for
+// streaming gRPC callers.
 func (q *MatchmakingQueue) JoinQueue(ctx context.Context, req *pb.JoinQueueRequest) (*pb.JoinQueueResponse, error) {
 	if req.PlayerId == "" {
 		return &pb.JoinQueueResponse{Ok: false, Reason: "player_id is required"}, nil
 	}
-	clientID := goverseapi.CallerClientID(ctx)
+	clientID := req.ClientId
+	if clientID == "" {
+		clientID = goverseapi.CallerClientID(ctx)
+	}
 	q.mu.Lock()
 	defer q.mu.Unlock()
 	for i, qp := range q.queued {
@@ -214,12 +220,17 @@ func (q *MatchmakingQueue) spawnMatch(matchID string, batch []queuedPlayer) erro
 	spawns := defaultSpawnPositions()
 	for i, qp := range batch {
 		spawn := spawns[i%len(spawns)]
-		req := &pb.AddPlayerRequest{PlayerId: qp.playerID, SpawnX: int32(spawn[0]), SpawnY: int32(spawn[1])}
-		// The server-side recorded client_id will be the queue object's
-		// callcontext, not the original player's. Carrying the player's
-		// client_id across actors is a future enhancement (PR 4 on web
-		// UI / PR 5 on stress test); for now the queue logs the mapping
-		// so the stress test driver can wire push routing externally.
+		req := &pb.AddPlayerRequest{
+			PlayerId: qp.playerID,
+			SpawnX:   int32(spawn[0]),
+			SpawnY:   int32(spawn[1]),
+			// Forward the player's original gate-assigned client id so
+			// Match's per-tick snapshot push lands on their SSE / gRPC
+			// stream rather than on the queue's. Without this, a Match
+			// spawned through matchmaking would broadcast into the void
+			// from the player's perspective.
+			ClientId: qp.clientID,
+		}
 		if _, err := q.callObject(ctx, "Match", matchID, "AddPlayer", req); err != nil {
 			q.Logger.Errorf("AddPlayer(%s, %s): %v", matchID, qp.playerID, err)
 		}

--- a/samples/bomberman/server/matchmaking_queue_test.go
+++ b/samples/bomberman/server/matchmaking_queue_test.go
@@ -262,6 +262,44 @@ type errFakeSpawn struct{ msg string }
 
 func (e errFakeSpawn) Error() string { return e.msg }
 
+// TestQueue_SpawnForwardsPlayerClientID is the regression that the
+// queue → Match.AddPlayer hop carries the player's original
+// gate-assigned client_id rather than the queue's own. Without it,
+// matches spawned via matchmaking would push snapshots back to the
+// queue object's stream instead of the players who joined.
+func TestQueue_SpawnForwardsPlayerClientID(t *testing.T) {
+	q, rec := newQueueForTest(t)
+	for _, name := range []string{"alice", "bob"} {
+		// JoinQueueRequest.client_id is the explicit override path
+		// browsers will use after learning their SSE id.
+		_, err := q.JoinQueue(context.Background(), &pb.JoinQueueRequest{
+			PlayerId: name, ClientId: "gate1/" + name,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	q.spawnIfReady()
+
+	calls := rec.snapshot()
+	addPlayerByID := map[string]*pb.AddPlayerRequest{}
+	for _, c := range calls {
+		if c.method == "AddPlayer" {
+			req := c.request.(*pb.AddPlayerRequest)
+			addPlayerByID[req.PlayerId] = req
+		}
+	}
+	for _, name := range []string{"alice", "bob"} {
+		req, ok := addPlayerByID[name]
+		if !ok {
+			t.Fatalf("no AddPlayer call for %q", name)
+		}
+		if got, want := req.ClientId, "gate1/"+name; got != want {
+			t.Fatalf("AddPlayer(%s).client_id = %q; want %q", name, got, want)
+		}
+	}
+}
+
 func TestQueue_QueueStatus_ReportsCounts(t *testing.T) {
 	q, _ := newQueueForTest(t)
 	_, _ = q.JoinQueue(context.Background(), &pb.JoinQueueRequest{PlayerId: "alice"})

--- a/samples/bomberman/web/game.js
+++ b/samples/bomberman/web/game.js
@@ -1,0 +1,550 @@
+// Bomberman web client. Talks to the goverse HTTP gate:
+//   GET  /api/v1/events/stream                                   (SSE)
+//   POST /api/v1/objects/call/{type}/{id}/{method}                (RPC)
+//
+// Wire format: every RPC body is base64-encoded protobuf wrapped in
+// google.protobuf.Any. SSE message events arrive in the same shape,
+// minus the JSON wrapper. We hand-roll a tiny varint encoder/decoder
+// here rather than pulling in protobuf.js — only MatchSnapshot and a
+// handful of request messages need to cross the wire.
+
+const API_BASE = inferApiBase();
+const TICK_HZ = 10;
+const BOARD_WIDTH = 13;
+const BOARD_HEIGHT = 11;
+
+// ---------- DOM refs ----------
+
+const elNickname = document.getElementById('nickname');
+const elJoinBtn  = document.getElementById('join-button');
+const elLobby    = document.getElementById('lobby');
+const elGame     = document.getElementById('game');
+const elStatus   = document.getElementById('lobby-status');
+const elMatchID  = document.getElementById('match-id');
+const elMatchSt  = document.getElementById('match-status');
+const elMyStats  = document.getElementById('my-stats');
+const elPlayers  = document.getElementById('players-list');
+const elBoard    = document.getElementById('board');
+const ctx2d      = elBoard.getContext('2d');
+
+// ---------- session state ----------
+
+let clientID = null;            // assigned by SSE register event
+let playerID = null;            // entered by user
+let matchID  = null;            // first MatchSnapshot fills this in
+let lastSnapshot = null;
+let inputState = { move: 0, placeBomb: false };
+let inputTimer = null;
+let eventSource = null;
+
+// ---------- entry ----------
+
+document.addEventListener('DOMContentLoaded', () => {
+  elBoard.tabIndex = 0; // focusable for keyboard
+  setStatus('Connecting…');
+  connectSSE();
+  elJoinBtn.addEventListener('click', onFindMatch);
+  elNickname.addEventListener('keydown', e => {
+    if (e.key === 'Enter' && !elJoinBtn.disabled) onFindMatch();
+  });
+});
+
+function inferApiBase() {
+  const params = new URLSearchParams(window.location.search);
+  const o = params.get('api');
+  if (o) return o;
+  const proto = window.location.protocol;
+  const host  = window.location.hostname;
+  return `${proto}//${host}:8080/api/v1`;
+}
+
+function setStatus(msg, kind) {
+  elStatus.textContent = msg;
+  elStatus.className = 'status' + (kind ? ' ' + kind : '');
+}
+
+// ---------- SSE ----------
+
+function connectSSE() {
+  eventSource = new EventSource(`${API_BASE}/events/stream`);
+  eventSource.addEventListener('register', e => {
+    const data = JSON.parse(e.data);
+    clientID = data.clientId;
+    elJoinBtn.disabled = false;
+    elJoinBtn.textContent = 'Find Match';
+    setStatus(`Connected as ${clientID}. Pick a nickname and queue up.`, 'success');
+  });
+  eventSource.addEventListener('message', e => {
+    const data = JSON.parse(e.data);
+    if (!data.type || !data.type.endsWith('bomberman.MatchSnapshot')) return;
+    const bytes = base64Decode(data.payload);
+    // Payload is a marshalled Any whose .value is the MatchSnapshot.
+    const inner = decodeAnyValue(bytes);
+    const snap = decodeMatchSnapshot(inner);
+    onSnapshot(snap);
+  });
+  eventSource.addEventListener('heartbeat', () => {});
+  eventSource.onerror = () => {
+    if (eventSource.readyState === EventSource.CLOSED) {
+      setStatus('Disconnected — reconnecting…', 'error');
+      setTimeout(connectSSE, 2000);
+    }
+  };
+}
+
+// ---------- HTTP RPC ----------
+
+async function callObject(objectType, objectID, method, requestBytes) {
+  // requestBytes is the marshalled Any (already base64 elsewhere).
+  const body = JSON.stringify({ request: base64Encode(requestBytes) });
+  const url  = `${API_BASE}/objects/call/${objectType}/${objectID}/${method}`;
+  const r    = await fetch(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body,
+  });
+  if (!r.ok) throw new Error(`${url}: HTTP ${r.status}`);
+  const j = await r.json();
+  if (!j.response) return null;
+  const respBytes = base64Decode(j.response);
+  return decodeAnyValue(respBytes); // returns the inner message bytes
+}
+
+// ---------- Lobby flow ----------
+
+async function onFindMatch() {
+  const nick = elNickname.value.trim();
+  if (!nick) { setStatus('Enter a nickname first.', 'error'); return; }
+  if (!clientID) { setStatus('Still connecting; try again in a second.', 'error'); return; }
+  playerID = nick;
+  elJoinBtn.disabled = true;
+  elJoinBtn.textContent = 'Queued…';
+  setStatus(`Queued as ${playerID}. Waiting for opponents…`);
+
+  const req = encodeJoinQueueRequest({ playerId: playerID, clientId: clientID });
+  const reqAny = wrapAny('type.googleapis.com/bomberman.JoinQueueRequest', req);
+  try {
+    const respBytes = await callObject('MatchmakingQueue', 'MatchmakingQueue', 'JoinQueue', reqAny);
+    const resp = decodeJoinQueueResponse(respBytes);
+    if (!resp.ok) {
+      setStatus(`Queue rejected: ${resp.reason || 'unknown'}`, 'error');
+      elJoinBtn.disabled = false;
+      elJoinBtn.textContent = 'Find Match';
+      return;
+    }
+    setStatus(`In queue at position ${resp.queuePosition}. The match will start once enough players are queued.`);
+  } catch (err) {
+    setStatus(`Queue error: ${err.message}`, 'error');
+    elJoinBtn.disabled = false;
+    elJoinBtn.textContent = 'Find Match';
+  }
+}
+
+// ---------- Snapshot handler ----------
+
+function onSnapshot(snap) {
+  // First snapshot identifies our match. After that, ignore snapshots
+  // belonging to other matches (e.g. spectator tabs sharing a node).
+  if (!matchID) {
+    matchID = snap.matchId;
+    elLobby.classList.add('hidden');
+    elGame.classList.remove('hidden');
+    elBoard.focus();
+    bindKeyboard();
+    startInputTimer();
+  } else if (snap.matchId !== matchID) {
+    return;
+  }
+  lastSnapshot = snap;
+  render(snap);
+  if (snap.status === 3 /* ENDED */) onMatchEnded(snap);
+}
+
+function onMatchEnded(snap) {
+  stopInputTimer();
+  const winner = snap.winnerId || 'no one (draw)';
+  elMatchSt.textContent = `Match over — winner: ${winner}`;
+  elJoinBtn.disabled = false;
+  elJoinBtn.textContent = 'Find another match';
+  // Reset matchID so the next match can take over the canvas.
+  matchID = null;
+}
+
+// ---------- Rendering ----------
+
+const TILE_SIZE = 40;
+const COLORS = {
+  empty:        '#1a1a22',
+  wall:         '#444455',
+  block:        '#7a5b35',
+  bomb:         '#222',
+  bombFlash:    '#cc4422',
+  explosion:    '#ff8833',
+  powerupBomb:  '#ff66aa',
+  powerupPower: '#66aaff',
+  powerupSpeed: '#aaff66',
+  playerColors: ['#5a7aff', '#ff5a7a', '#5aff7a', '#ffaa5a', '#aa5aff', '#5affff', '#ffff5a', '#ff5aff'],
+};
+
+function render(snap) {
+  // Static layout
+  ctx2d.fillStyle = COLORS.empty;
+  ctx2d.fillRect(0, 0, elBoard.width, elBoard.height);
+  for (let y = 0; y < snap.height; y++) {
+    for (let x = 0; x < snap.width; x++) {
+      const t = snap.tiles[y * snap.width + x];
+      if (t === 1)      drawTile(x, y, COLORS.wall);
+      else if (t === 2) drawTile(x, y, COLORS.block);
+    }
+  }
+  // Powerups under everything else
+  for (const p of snap.powerups) {
+    let c = COLORS.powerupBomb;
+    if (p.kind === 2) c = COLORS.powerupPower;
+    if (p.kind === 3) c = COLORS.powerupSpeed;
+    drawCircle(p.x, p.y, c, 0.30);
+  }
+  // Bombs
+  for (const b of snap.bombs) {
+    const flashing = b.ticksRemaining <= 5 && (b.ticksRemaining % 2 === 0);
+    drawCircle(b.x, b.y, flashing ? COLORS.bombFlash : COLORS.bomb, 0.36);
+  }
+  // Explosions on top of everything except live players
+  for (const e of snap.explosions) {
+    drawTile(e.x, e.y, COLORS.explosion);
+  }
+  // Players
+  const playersByID = {};
+  snap.players.forEach((p, i) => {
+    playersByID[p.playerId] = p;
+    if (!p.alive) return;
+    const color = COLORS.playerColors[i % COLORS.playerColors.length];
+    drawCircle(p.x, p.y, color, 0.42);
+  });
+
+  updateHUD(snap, playersByID);
+}
+
+function drawTile(x, y, color) {
+  ctx2d.fillStyle = color;
+  ctx2d.fillRect(x * TILE_SIZE, y * TILE_SIZE, TILE_SIZE, TILE_SIZE);
+}
+
+function drawCircle(x, y, color, radiusFrac) {
+  const cx = x * TILE_SIZE + TILE_SIZE / 2;
+  const cy = y * TILE_SIZE + TILE_SIZE / 2;
+  const r  = TILE_SIZE * radiusFrac;
+  ctx2d.fillStyle = color;
+  ctx2d.beginPath();
+  ctx2d.arc(cx, cy, r, 0, Math.PI * 2);
+  ctx2d.fill();
+}
+
+function updateHUD(snap, playersByID) {
+  elMatchID.textContent = snap.matchId;
+  const statusName = ['?', 'Lobby', 'Running', 'Ended'][snap.status] || '?';
+  elMatchSt.textContent = `Tick ${snap.tick} · ${statusName}`;
+  const me = playersByID[playerID];
+  if (me) {
+    elMyStats.textContent = `you  bombs:${me.bombCapacity}  power:${me.bombPower}  speed:${me.speed}`;
+  }
+  elPlayers.innerHTML = '';
+  snap.players.forEach((p, i) => {
+    const chip = document.createElement('span');
+    chip.className = 'player-chip';
+    if (!p.alive) chip.classList.add('dead');
+    if (p.playerId === playerID) chip.classList.add('you');
+    chip.style.borderColor = COLORS.playerColors[i % COLORS.playerColors.length];
+    chip.textContent = p.playerId;
+    elPlayers.appendChild(chip);
+  });
+}
+
+// ---------- Keyboard input ----------
+
+const KEY_MOVE = {
+  'ArrowUp': 1, 'w': 1, 'W': 1,
+  'ArrowDown': 2, 's': 2, 'S': 2,
+  'ArrowLeft': 3, 'a': 3, 'A': 3,
+  'ArrowRight': 4, 'd': 4, 'D': 4,
+};
+
+function bindKeyboard() {
+  // Track held direction; release reverts to NONE so the player stops.
+  let heldKey = null;
+  const onDown = e => {
+    if (e.key === ' ') { inputState.placeBomb = true; e.preventDefault(); return; }
+    const dir = KEY_MOVE[e.key];
+    if (dir === undefined) return;
+    heldKey = e.key;
+    inputState.move = dir;
+    e.preventDefault();
+  };
+  const onUp = e => {
+    if (e.key === heldKey) { heldKey = null; inputState.move = 0; }
+  };
+  document.addEventListener('keydown', onDown);
+  document.addEventListener('keyup', onUp);
+}
+
+function startInputTimer() {
+  if (inputTimer) return;
+  inputTimer = setInterval(sendInput, 1000 / TICK_HZ);
+}
+
+function stopInputTimer() {
+  if (inputTimer) { clearInterval(inputTimer); inputTimer = null; }
+}
+
+async function sendInput() {
+  if (!matchID) return;
+  // Snapshot and reset placeBomb so a single space-press fires once.
+  const placeBomb = inputState.placeBomb;
+  inputState.placeBomb = false;
+  if (inputState.move === 0 && !placeBomb) return; // no-op tick
+  const req = encodePlayerInputRequest({
+    playerId: playerID,
+    move: inputState.move,
+    placeBomb,
+  });
+  const reqAny = wrapAny('type.googleapis.com/bomberman.PlayerInputRequest', req);
+  try {
+    await callObject('Match', matchID, 'HandleInput', reqAny);
+  } catch (err) {
+    console.warn('HandleInput failed:', err);
+  }
+}
+
+// ==================================================================
+// Tiny protobuf helpers (encoders/decoders for the messages we use)
+// ==================================================================
+
+function base64Encode(bytes) {
+  let s = '';
+  for (let i = 0; i < bytes.length; i++) s += String.fromCharCode(bytes[i]);
+  return btoa(s);
+}
+function base64Decode(b64) {
+  const s = atob(b64);
+  const out = new Uint8Array(s.length);
+  for (let i = 0; i < s.length; i++) out[i] = s.charCodeAt(i);
+  return out;
+}
+
+// --- low-level wire format ---
+
+function encodeVarint(v) {
+  const out = [];
+  while (v >= 0x80) { out.push((v & 0x7f) | 0x80); v >>>= 7; }
+  out.push(v & 0x7f);
+  return out;
+}
+
+function encodeTag(field, wire) { return encodeVarint((field << 3) | wire); }
+
+function encodeLenDelim(field, bytes) {
+  const out = [];
+  out.push(...encodeTag(field, 2));
+  out.push(...encodeVarint(bytes.length));
+  for (let i = 0; i < bytes.length; i++) out.push(bytes[i]);
+  return out;
+}
+
+function encodeStringField(field, str) {
+  const u = new TextEncoder().encode(str);
+  return encodeLenDelim(field, u);
+}
+
+function encodeVarintField(field, v) {
+  return [...encodeTag(field, 0), ...encodeVarint(v)];
+}
+
+function encodeBoolField(field, v) { return encodeVarintField(field, v ? 1 : 0); }
+
+function decodeVarint(buf, off) {
+  let v = 0, shift = 0, b;
+  do { b = buf[off++]; v |= (b & 0x7f) << shift; shift += 7; } while (b & 0x80);
+  return [v >>> 0, off];
+}
+
+// wrapAny constructs the Any envelope used by every gate request /
+// response: { type_url, value }.
+function wrapAny(typeURL, valueBytes) {
+  const out = [];
+  out.push(...encodeStringField(1, typeURL));
+  out.push(...encodeLenDelim(2, valueBytes));
+  return new Uint8Array(out);
+}
+
+// decodeAnyValue parses the Any wrapper and returns the inner value.
+function decodeAnyValue(bytes) {
+  let off = 0;
+  let valueBytes = null;
+  while (off < bytes.length) {
+    const [tag, next] = decodeVarint(bytes, off); off = next;
+    const field = tag >>> 3, wire = tag & 7;
+    if (wire === 2) {
+      const [len, n2] = decodeVarint(bytes, off); off = n2;
+      if (field === 2) valueBytes = bytes.slice(off, off + len);
+      off += len;
+    } else if (wire === 0) { const [, n2] = decodeVarint(bytes, off); off = n2; }
+    else throw new Error(`unsupported wire type ${wire} in Any`);
+  }
+  return valueBytes || new Uint8Array();
+}
+
+// --- request encoders ---
+
+function encodeJoinQueueRequest({ playerId, clientId }) {
+  const out = [];
+  if (playerId) out.push(...encodeStringField(1, playerId));
+  if (clientId) out.push(...encodeStringField(2, clientId));
+  return new Uint8Array(out);
+}
+
+function encodePlayerInputRequest({ playerId, move, placeBomb }) {
+  const out = [];
+  if (playerId) out.push(...encodeStringField(1, playerId));
+  if (move)     out.push(...encodeVarintField(2, move));
+  if (placeBomb) out.push(...encodeBoolField(3, true));
+  return new Uint8Array(out);
+}
+
+// --- response decoders ---
+
+function decodeJoinQueueResponse(bytes) {
+  const out = { ok: false, reason: '', queuePosition: 0 };
+  let off = 0;
+  while (off < bytes.length) {
+    const [tag, n] = decodeVarint(bytes, off); off = n;
+    const field = tag >>> 3, wire = tag & 7;
+    if (wire === 0) {
+      const [v, n2] = decodeVarint(bytes, off); off = n2;
+      if (field === 1) out.ok = !!v;
+      else if (field === 3) out.queuePosition = v;
+    } else if (wire === 2) {
+      const [len, n2] = decodeVarint(bytes, off); off = n2;
+      const slice = bytes.slice(off, off + len); off += len;
+      if (field === 2) out.reason = new TextDecoder().decode(slice);
+    }
+  }
+  return out;
+}
+
+function decodeMatchSnapshot(bytes) {
+  const out = {
+    matchId: '', status: 0, tick: 0, width: 0, height: 0,
+    tiles: [], players: [], bombs: [], explosions: [], powerups: [],
+    winnerId: '',
+  };
+  let off = 0;
+  while (off < bytes.length) {
+    const [tag, n] = decodeVarint(bytes, off); off = n;
+    const field = tag >>> 3, wire = tag & 7;
+    if (wire === 0) {
+      const [v, n2] = decodeVarint(bytes, off); off = n2;
+      if (field === 2) out.status = v;
+      else if (field === 3) out.tick = v;
+      else if (field === 4) out.width = v;
+      else if (field === 5) out.height = v;
+      else if (field === 6) out.tiles.push(v); // packed=false fallback
+    } else if (wire === 2) {
+      const [len, n2] = decodeVarint(bytes, off); off = n2;
+      const slice = bytes.slice(off, off + len); off += len;
+      switch (field) {
+        case 1: out.matchId = new TextDecoder().decode(slice); break;
+        case 6: { // tiles repeated enum, packed
+          let p = 0;
+          while (p < slice.length) {
+            const [v, np] = decodeVarint(slice, p); p = np;
+            out.tiles.push(v);
+          }
+          break;
+        }
+        case 7:  out.players.push(decodePlayerState(slice)); break;
+        case 8:  out.bombs.push(decodeBombState(slice)); break;
+        case 9:  out.explosions.push(decodeExplosionState(slice)); break;
+        case 10: out.powerups.push(decodePowerupState(slice)); break;
+        case 11: out.winnerId = new TextDecoder().decode(slice); break;
+      }
+    }
+  }
+  return out;
+}
+
+function decodePlayerState(bytes) {
+  const out = { playerId: '', x: 0, y: 0, alive: false, bombCapacity: 0, bombPower: 0, speed: 0, activeBombs: 0 };
+  let off = 0;
+  while (off < bytes.length) {
+    const [tag, n] = decodeVarint(bytes, off); off = n;
+    const field = tag >>> 3, wire = tag & 7;
+    if (wire === 0) {
+      const [v, n2] = decodeVarint(bytes, off); off = n2;
+      if (field === 2) out.x = v;
+      else if (field === 3) out.y = v;
+      else if (field === 4) out.alive = !!v;
+      else if (field === 5) out.bombCapacity = v;
+      else if (field === 6) out.bombPower = v;
+      else if (field === 7) out.speed = v;
+      else if (field === 8) out.activeBombs = v;
+    } else if (wire === 2) {
+      const [len, n2] = decodeVarint(bytes, off); off = n2;
+      const slice = bytes.slice(off, off + len); off += len;
+      if (field === 1) out.playerId = new TextDecoder().decode(slice);
+    }
+  }
+  return out;
+}
+
+function decodeBombState(bytes) {
+  const out = { x: 0, y: 0, ownerId: '', power: 0, ticksRemaining: 0 };
+  let off = 0;
+  while (off < bytes.length) {
+    const [tag, n] = decodeVarint(bytes, off); off = n;
+    const field = tag >>> 3, wire = tag & 7;
+    if (wire === 0) {
+      const [v, n2] = decodeVarint(bytes, off); off = n2;
+      if (field === 1) out.x = v;
+      else if (field === 2) out.y = v;
+      else if (field === 4) out.power = v;
+      else if (field === 5) out.ticksRemaining = v;
+    } else if (wire === 2) {
+      const [len, n2] = decodeVarint(bytes, off); off = n2;
+      const slice = bytes.slice(off, off + len); off += len;
+      if (field === 3) out.ownerId = new TextDecoder().decode(slice);
+    }
+  }
+  return out;
+}
+
+function decodeExplosionState(bytes) {
+  const out = { x: 0, y: 0, ticksRemaining: 0 };
+  let off = 0;
+  while (off < bytes.length) {
+    const [tag, n] = decodeVarint(bytes, off); off = n;
+    const field = tag >>> 3, wire = tag & 7;
+    if (wire === 0) {
+      const [v, n2] = decodeVarint(bytes, off); off = n2;
+      if (field === 1) out.x = v;
+      else if (field === 2) out.y = v;
+      else if (field === 3) out.ticksRemaining = v;
+    }
+  }
+  return out;
+}
+
+function decodePowerupState(bytes) {
+  const out = { x: 0, y: 0, kind: 0 };
+  let off = 0;
+  while (off < bytes.length) {
+    const [tag, n] = decodeVarint(bytes, off); off = n;
+    const field = tag >>> 3, wire = tag & 7;
+    if (wire === 0) {
+      const [v, n2] = decodeVarint(bytes, off); off = n2;
+      if (field === 1) out.x = v;
+      else if (field === 2) out.y = v;
+      else if (field === 3) out.kind = v;
+    }
+  }
+  return out;
+}

--- a/samples/bomberman/web/index.html
+++ b/samples/bomberman/web/index.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Bomberman — Goverse Demo</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div id="app">
+    <header>
+      <h1>Bomberman <span class="subtitle">— a Goverse multiplayer demo</span></h1>
+    </header>
+
+    <section id="lobby" class="panel">
+      <h2>Find a Match</h2>
+      <p>
+        Pick a nickname and queue up. Two or more players need to be
+        queued before the cluster spawns a match — open this page in a
+        second browser tab to play against yourself.
+      </p>
+      <label>
+        Nickname
+        <input id="nickname" type="text" maxlength="20" placeholder="alice" autocomplete="off">
+      </label>
+      <button id="join-button" disabled>Connect…</button>
+      <p id="lobby-status" class="status"></p>
+    </section>
+
+    <section id="game" class="panel hidden">
+      <div id="hud">
+        <div id="match-id"></div>
+        <div id="match-status"></div>
+        <div id="my-stats"></div>
+      </div>
+      <canvas id="board" width="520" height="440"></canvas>
+      <div id="players-list"></div>
+      <div id="controls-help">
+        <strong>Controls:</strong> WASD / arrow keys to move, Space to drop a bomb.
+      </div>
+    </section>
+  </div>
+  <script src="game.js"></script>
+</body>
+</html>

--- a/samples/bomberman/web/style.css
+++ b/samples/bomberman/web/style.css
@@ -1,0 +1,152 @@
+* { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  background: #1a1a1f;
+  color: #e8e8ee;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif;
+  min-height: 100vh;
+  display: flex;
+  justify-content: center;
+}
+
+#app {
+  width: 100%;
+  max-width: 720px;
+  padding: 24px;
+}
+
+header {
+  margin-bottom: 24px;
+  text-align: center;
+}
+
+h1 {
+  margin: 0;
+  font-size: 1.8em;
+  letter-spacing: 0.02em;
+}
+
+.subtitle {
+  font-size: 0.55em;
+  color: #888899;
+  font-weight: normal;
+}
+
+.panel {
+  background: #25252e;
+  border: 1px solid #38384a;
+  border-radius: 8px;
+  padding: 20px;
+  margin-bottom: 20px;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.3);
+}
+
+.panel h2 {
+  margin-top: 0;
+  font-size: 1.1em;
+  color: #b8b8d8;
+}
+
+#lobby p {
+  color: #a0a0b0;
+  font-size: 0.92em;
+  line-height: 1.5;
+}
+
+label {
+  display: block;
+  margin: 14px 0 6px;
+  font-size: 0.9em;
+  color: #b0b0c0;
+}
+
+input[type="text"] {
+  width: 100%;
+  padding: 10px 12px;
+  background: #1d1d24;
+  border: 1px solid #4a4a5e;
+  border-radius: 4px;
+  color: #e8e8ee;
+  font-size: 1em;
+  font-family: inherit;
+}
+
+input[type="text"]:focus {
+  outline: none;
+  border-color: #6a8aff;
+}
+
+button {
+  margin-top: 14px;
+  padding: 10px 24px;
+  background: #5a7aff;
+  color: white;
+  border: none;
+  border-radius: 4px;
+  font-size: 1em;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.15s;
+}
+
+button:hover:not(:disabled) { background: #6a8aff; }
+button:disabled { background: #444455; cursor: not-allowed; }
+
+.status { margin-top: 12px; font-size: 0.9em; color: #88a; min-height: 1.4em; }
+.status.error { color: #ff8a8a; }
+.status.success { color: #8aff8a; }
+
+.hidden { display: none; }
+
+#hud {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 14px;
+  font-size: 0.9em;
+  color: #b0b0c0;
+}
+
+#match-id { font-family: ui-monospace, monospace; font-size: 0.85em; color: #889; }
+#match-status { font-weight: 600; }
+#my-stats { font-family: ui-monospace, monospace; }
+
+#board {
+  display: block;
+  margin: 0 auto;
+  background: #0d0d12;
+  border: 1px solid #38384a;
+  border-radius: 4px;
+  image-rendering: pixelated;
+  outline: none;
+}
+
+#board:focus { border-color: #6a8aff; }
+
+#players-list {
+  margin-top: 14px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  justify-content: center;
+  font-size: 0.85em;
+}
+
+.player-chip {
+  padding: 4px 10px;
+  border-radius: 12px;
+  background: #1d1d24;
+  border: 1px solid #38384a;
+  font-family: ui-monospace, monospace;
+}
+
+.player-chip.dead { opacity: 0.4; text-decoration: line-through; }
+.player-chip.you { box-shadow: 0 0 0 2px #5a7aff inset; }
+
+#controls-help {
+  margin-top: 14px;
+  text-align: center;
+  font-size: 0.85em;
+  color: #888899;
+}


### PR DESCRIPTION
## Summary

PR 4 of 5 in the bomberman series. Adds the browser client and the small server-side plumbing that makes matchmaking-spawned matches push snapshots to the right SSE subscriber.

**Server changes**
- \`AddPlayerRequest.client_id\` and \`JoinQueueRequest.client_id\` (both new fields). When set, the server prefers them over \`goverseapi.CallerClientID(ctx)\` — required so HTTP/SSE callers can carry their gate-assigned id across the queue → Match hop. Direct streaming-gRPC clients keep working unchanged.
- \`spawnMatch\` now forwards the queued player's \`client_id\` into \`AddPlayerRequest\`. Without this, a Match spawned via matchmaking would broadcast snapshots into the queue object's stream — invisible to the player who joined.

**Web client (\`samples/bomberman/web/\`)**
- \`index.html\` + \`style.css\` — minimal lobby (nickname + Find Match) and canvas game view.
- \`game.js\` (~520 LOC):
  - SSE on \`/api/v1/events/stream\` → register event yields our \`client_id\`; \`bomberman.MatchSnapshot\` push events are decoded and rendered.
  - POST to \`MatchmakingQueue.JoinQueue\` with the SSE \`client_id\`.
  - 10 Hz keyboard input pump (held WASD/arrow → \`Move\`, space → \`PlaceBomb\`) sent via \`Match.HandleInput\`.
  - Hand-rolled protobuf wire-format encoders/decoders for the four messages we cross (\`MatchSnapshot\`, \`JoinQueueResponse\`, \`PlayerInputRequest\`, \`AddPlayerRequest\`) so the sample stays dependency-free.

**Out of scope (lands in PR 5)**: static-file serving for \`web/\` (run \`python3 -m http.server\` from \`samples/bomberman/web/\` for now), stress-test invariants, CI wiring.

## Test plan
- [x] \`go build ./samples/bomberman/...\`
- [x] \`go vet ./samples/bomberman/...\`
- [x] \`go test ./samples/bomberman/...\` (existing 24 tests + new \`TestQueue_SpawnForwardsPlayerClientID\`)
- [x] JS structural sanity (braces match, all referenced functions defined)

🤖 Generated with [Claude Code](https://claude.com/claude-code)