### PR TITLE
Add bomberman sample (5/5): stress test + README + CI

### DIFF
--- a/.github/workflows/stress.yml
+++ b/.github/workflows/stress.yml
@@ -233,3 +233,63 @@ jobs:
           name: stress-wallet
           fail_ci_if_error: false
           token: ${{ secrets.CODECOV_TOKEN }}
+
+  bomberman-stress-test:
+    # Drives the bomberman sample end to end: N concurrent clients
+    # cycle through JoinQueue → wait-for-match-end → JoinQueue, and
+    # the test fails if any player's total_matches doesn't increment
+    # by exactly 1 per cycle (proving Match → Player.RecordMatchResult
+    # reliable-call dedup holds). Postgres is required because the
+    # reliable-call dedup state is persisted there. Match length is
+    # capped to 5 s via BOMBERMAN_MATCH_TIME_LIMIT_TICKS so a CI run
+    # turns over many matches.
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Setup test environment
+        uses: ./.github/actions/setup-test-env
+        with:
+          enable-postgres: 'true'
+
+      - name: Provision Postgres role for bomberman config
+        run: |
+          sudo -u postgres psql -c "DO \$\$ BEGIN IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname='goverse') THEN CREATE ROLE goverse LOGIN PASSWORD 'goverse'; END IF; END \$\$;"
+          sudo -u postgres psql -c "GRANT ALL PRIVILEGES ON DATABASE goverse TO goverse;"
+          sudo -u postgres psql -d goverse -c "GRANT ALL ON SCHEMA public TO goverse;"
+
+      - name: Initialize Goverse schema
+        run: go run ./cmd/pgadmin --config samples/bomberman/stress_config.yml init
+
+      - name: Install PyYAML
+        run: python3 -m pip install pyyaml
+
+      - name: Create coverage directory
+        run: mkdir -p /tmp/coverage-bomberman
+
+      - name: Run bomberman stress test
+        env:
+          GOCOVERDIR: /tmp/coverage-bomberman
+          ENABLE_COVERAGE: "true"
+        run: |
+          python3 samples/bomberman/stress_test.py --duration 120 --clients 8 --match-ticks 50
+
+      - name: Convert coverage data to text format
+        run: |
+          if [ -d /tmp/coverage-bomberman ]; then
+            go tool covdata textfmt -i=/tmp/coverage-bomberman -o=coverage-bomberman-stress.out
+          else
+            echo "No coverage data found at /tmp/coverage-bomberman"; exit 0;
+          fi
+
+      - name: Upload coverage to Codecov
+        if: ${{ hashFiles('coverage-bomberman-stress.out') != '' }}
+        uses: codecov/codecov-action@v6
+        with:
+          files: ./coverage-bomberman-stress.out
+          flags: stress-bomberman
+          name: stress-bomberman
+          fail_ci_if_error: false
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/samples/bomberman/BombermanServer.py
+++ b/samples/bomberman/BombermanServer.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+"""BombermanServer helper — thin wrapper around the shared ServerProcess base."""
+import os
+import sys
+from pathlib import Path
+
+# samples/bomberman/BombermanServer.py -> repo root
+REPO_ROOT = Path(__file__).parent.parent.parent.resolve()
+sys.path.insert(0, str(REPO_ROOT))
+COMMON_DIR = REPO_ROOT / 'samples' / 'common'
+sys.path.insert(0, str(COMMON_DIR))
+
+from ServerProcess import ServerProcess, ServerStopTimeout
+
+# Back-compat alias for any future callers that key on the
+# sample-specific exception name.
+BombermanServerStopTimeout = ServerStopTimeout
+
+
+class BombermanServer(ServerProcess):
+    """Manages a Goverse bomberman server (samples/bomberman) subprocess.
+
+    Honours BOMBERMAN_MATCH_TIME_LIMIT_TICKS in the parent environment —
+    the stress test sets it low (e.g. 50 ticks = 5 s) so each match
+    concludes quickly as a draw, exercising the end-of-match
+    RecordMatchResult reliable-call path many times in a CI window.
+    """
+
+    def __init__(self, server_index=0, binary_path=None, config_file=None,
+                 node_id=None, build_if_needed=True):
+        super().__init__(
+            kind="Bomberman",
+            binary_path=binary_path or '/tmp/bomberman_server',
+            build_source_path='./samples/bomberman/server/',
+            coverage_prefix='bomberman_server',
+            server_index=server_index,
+            config_file=config_file,
+            node_id=node_id,
+            build_if_needed=build_if_needed,
+        )

--- a/samples/bomberman/README.md
+++ b/samples/bomberman/README.md
@@ -1,0 +1,113 @@
+# Bomberman Sample
+
+A multi-player Bomberman demo showing **how a real-time game maps onto
+the goverse virtual-actor model**. Each match is a goverse object that
+ticks at 10 Hz and broadcasts authoritative state to its players;
+matchmaking, persistent stats, and exactly-once stat updates use the
+same primitives any other application would.
+
+## Object model
+
+| Object             | Lifetime          | Role                                                             |
+| ------------------ | ----------------- | ---------------------------------------------------------------- |
+| `Match`            | per-game          | 13×11 grid, 10 Hz tick loop, push-broadcasts MatchSnapshot       |
+| `Player`           | per-user          | Persistent stats: total matches, wins, losses, last match id     |
+| `MatchmakingQueue` | singleton         | Auto-loaded; FIFO that batches queued players into Matches       |
+
+Cross-object hops:
+
+- `MatchmakingQueue → Match.AddPlayer / StartMatch` uses plain
+  `goverseapi.CallObject`. MatchState already rejects duplicate adds
+  and double-starts at the data layer; a transient failure costs at
+  most one ruined match for the affected players, no permanent state
+  at risk.
+- `Match → Player.RecordMatchResult` uses **`goverseapi.ReliableCallObject`**
+  with a stable per-player `call_id`. This is the *only* hop that
+  mutates permanent reward state, so reliable-call dedup is the
+  difference between a single transient timeout being eaten silently
+  and a player's win count jumping from 1 to 2. `recordResults`
+  retries with exponential backoff under a 60 s budget, so transient
+  failures become eventual consistency.
+
+## Running locally
+
+You need:
+
+- Go 1.25+, Python 3.10+ with `grpcio`, `grpcio-tools`, `pyyaml`
+- `protoc` plus `protoc-gen-go` and `protoc-gen-go-grpc` on `PATH`
+- **Postgres** on `localhost:5432` (`docker compose up -d postgres etcd`
+  from the repo root sets up both)
+- **etcd** on `localhost:2379` (same compose file)
+
+```bash
+# 1. Generate proto artifacts (the top-level script picks up sample protos)
+./script/compile-proto.sh
+
+# 2. Initialise Postgres schema (reliable-call dedup state lives there)
+go run ./cmd/pgadmin --config samples/bomberman/stress_config.yml init
+
+# 3. Run the stress test (60 s, 8 clients, fast 5-second matches)
+python3 samples/bomberman/stress_test.py --duration 60 --clients 8
+```
+
+The stress driver spins up 1 inspector + 3 server nodes + 2 gates,
+launches N concurrent fake players, and runs each through repeated
+JoinQueue → wait-for-match-end → JoinQueue cycles. Successful run
+ends with:
+
+```
+cycles=...  rpc_errors=0  timeouts=0  exactly_once_violations=0
+✅ stress-player-000: 12 cycles, server total=12 wins=0 losses=12
+...
+✅ bomberman stress test passed
+```
+
+## Playing in a browser
+
+The web UI in `web/` is a canvas-based client that talks to the
+goverse HTTP gate via SSE for snapshot push and POST for inputs.
+
+```bash
+# 1. Start the cluster (see Running locally above for prerequisites)
+go run ./cmd/inspector --config samples/bomberman/stress_config.yml &
+go run ./samples/bomberman/server --config samples/bomberman/stress_config.yml --node-id bomberman-node-1 &
+go run ./samples/bomberman/server --config samples/bomberman/stress_config.yml --node-id bomberman-node-2 &
+go run ./samples/bomberman/server --config samples/bomberman/stress_config.yml --node-id bomberman-node-3 &
+go run ./cmd/gate     --config samples/bomberman/stress_config.yml --gate-id bomberman-gate-1 &
+
+# 2. Serve the web/ folder; the gate exposes /api/v1 on port 8080.
+python3 -m http.server 8000 --directory samples/bomberman/web
+```
+
+Open `http://localhost:8000`, enter a nickname, click **Find Match**,
+then open the same URL in a second tab and queue up a second player.
+Once two players are queued the cluster spawns a Match and both
+canvases start receiving 10 Hz snapshot pushes. WASD or arrows to
+move, Space to drop a bomb.
+
+## Stress-test invariants
+
+The driver asserts three properties at the end of a run; all three
+are exactly-once contracts that would fail if reliable-call dedup or
+MatchState's data-layer guards regressed:
+
+1. **Exactly-once stat updates** — each JoinQueue cycle must increment
+   the player's `total_matches` by exactly 1. The retry loop inside
+   `Match.recordResults` keeps trying until the call lands, but the
+   stable per-player `call_id` ensures that lands at most once.
+2. **Cycle accounting** — across all clients, completed cycles sum to
+   server-reported `total_matches`. Catches drift from missed credits.
+3. **Stats arithmetic** — `total_matches == wins + losses` for every
+   player. Pure data invariant, but cheap to verify.
+
+## File map
+
+- `proto/bomberman.proto` — every message: snapshot, RPC requests / responses, persistence blob.
+- `server/match.go`, `server/match_state.go` — Match goverse object + pure game logic.
+- `server/player.go` — Player goverse object with ToData/FromData persistence.
+- `server/matchmaking_queue.go` — MatchmakingQueue singleton with internal spawn loop.
+- `server/main.go` — registers the three object types.
+- `web/index.html`, `web/style.css`, `web/game.js` — browser client.
+- `stress_config.yml` — 1 inspector + 3 nodes + 2 gates; Postgres + etcd wiring.
+- `BombermanServer.py` — subprocess wrapper used by the stress driver.
+- `stress_test.py` — the correctness stress driver.

--- a/samples/bomberman/server/match_state.go
+++ b/samples/bomberman/server/match_state.go
@@ -3,6 +3,8 @@ package main
 import (
 	"fmt"
 	"math/rand"
+	"os"
+	"strconv"
 
 	pb "github.com/xiaonanln/goverse/samples/bomberman/proto"
 )
@@ -11,19 +13,34 @@ import (
 // Super Bomberman: 13x11 grid, 10Hz tick, 2 s bomb fuse, 0.5 s
 // explosion afterglow, 30 % drop chance per destroyed block.
 const (
-	GridWidth         = 13
-	GridHeight        = 11
-	TickHz            = 10
-	BombFuseTicks     = 20
-	ExplosionTicks    = 5
-	MatchTimeLimit    = 1800 // 3 minutes at 10 Hz
-	BlockDropPowerup  = 0.30
-	DefaultBombCap    = 1
-	DefaultBombPower  = 2
-	DefaultSpeed      = 1
-	MinPlayersToStart = 2
-	MaxPlayers        = 8
+	GridWidth                   = 13
+	GridHeight                  = 11
+	TickHz                      = 10
+	BombFuseTicks               = 20
+	ExplosionTicks              = 5
+	DefaultMatchTimeLimitTicks  = 1800 // 3 minutes at 10 Hz
+	BlockDropPowerup            = 0.30
+	DefaultBombCap              = 1
+	DefaultBombPower            = 2
+	DefaultSpeed                = 1
+	MinPlayersToStart           = 2
+	MaxPlayers                  = 8
 )
+
+// MatchTimeLimit is read once at process start. It defaults to
+// DefaultMatchTimeLimitTicks (3 minutes) but can be overridden via
+// BOMBERMAN_MATCH_TIME_LIMIT_TICKS so the stress test can drive short
+// matches and exercise many end-of-match cycles in a CI window.
+var MatchTimeLimit = readMatchTimeLimit()
+
+func readMatchTimeLimit() int {
+	if v := os.Getenv("BOMBERMAN_MATCH_TIME_LIMIT_TICKS"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			return n
+		}
+	}
+	return DefaultMatchTimeLimitTicks
+}
 
 // Tile values mirror the proto Tile enum so we can convert in O(1).
 type Tile int8

--- a/samples/bomberman/stress_config.yml
+++ b/samples/bomberman/stress_config.yml
@@ -1,0 +1,58 @@
+# Bomberman stress test cluster — 1 inspector, 3 server nodes, 2 gates.
+# Reliable calls (Match → Player.RecordMatchResult on match end) require
+# Postgres-backed persistence, so this config wires it in.
+
+version: 1
+
+postgres:
+  host: "127.0.0.1"
+  port: 5432
+  user: "goverse"
+  password: "goverse"
+  database: "goverse"
+  sslmode: "disable"
+  max_open_conns: 4
+  max_idle_conns: 4
+
+inspector:
+  http_addr: "0.0.0.0:8190"
+  grpc_addr: "0.0.0.0:8191"
+  advertise_addr: "localhost:8191"
+
+cluster:
+  shards: 64
+  provider: "etcd"
+  etcd:
+    endpoints:
+      - "127.0.0.1:2379"
+    prefix: "/goverse/bomberman-stress-test"
+
+  # MatchmakingQueue is a singleton: the leader services it, but every
+  # node loads the type so the object survives shard re-ownership
+  # without an explicit re-creation step.
+  auto_load_objects:
+    - type: "MatchmakingQueue"
+      id: "MatchmakingQueue"
+
+nodes:
+  - id: "bomberman-node-1"
+    grpc_addr: "0.0.0.0:9411"
+    advertise_addr: "localhost:9411"
+    http_addr: "0.0.0.0:8411"
+
+  - id: "bomberman-node-2"
+    grpc_addr: "0.0.0.0:9412"
+    advertise_addr: "localhost:9412"
+    http_addr: "0.0.0.0:8412"
+
+  - id: "bomberman-node-3"
+    grpc_addr: "0.0.0.0:9413"
+    advertise_addr: "localhost:9413"
+    http_addr: "0.0.0.0:8413"
+
+gates:
+  - id: "bomberman-gate-1"
+    grpc_addr: "0.0.0.0:10311"
+
+  - id: "bomberman-gate-2"
+    grpc_addr: "0.0.0.0:10312"

--- a/samples/bomberman/stress_test.py
+++ b/samples/bomberman/stress_test.py
@@ -1,0 +1,425 @@
+#!/usr/bin/env python3
+"""Stress test for the bomberman sample.
+
+Spawns a 3-node / 2-gate cluster with an auto-loaded MatchmakingQueue,
+then drives N concurrent clients through repeated JoinQueue → wait-for-
+match-to-end → JoinQueue cycles. Matches are configured to end as
+draws after BOMBERMAN_MATCH_TIME_LIMIT_TICKS (default 50 = 5 s) so
+the loop turns over quickly and we exercise many end-of-match
+RecordMatchResult reliable calls per CI window.
+
+Invariants:
+
+1. **Exactly-once stat updates**: each JoinQueue cycle increments the
+   player's total_matches by exactly 1. Reliable-call dedup is the only
+   thing keeping this true — if Match.recordResults retried without
+   stable call_ids, total_matches would jump by 2 or more.
+
+2. **Cycle accounting**: each client's recorded cycle count equals the
+   final total_matches read from the server. Cumulative across all
+   clients, the matchmaker's view should be consistent.
+
+3. **No abandoned players**: every client that completed at least one
+   cycle has total_matches > 0 at the end.
+
+Postgres + etcd must be running (reliable-call dedup persists in
+Postgres; cluster coordination uses etcd).
+"""
+
+import argparse
+import os
+import random
+import signal
+import socket
+import sys
+import threading
+import time
+from collections import defaultdict
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Dict, List, Optional
+
+# --- path bootstrap ---------------------------------------------------
+REPO_ROOT = Path(__file__).parent.parent.parent.resolve()
+sys.path.insert(0, str(REPO_ROOT))
+COMMON_DIR = REPO_ROOT / 'samples' / 'common'
+sys.path.insert(0, str(COMMON_DIR))
+CHAT_DIR = REPO_ROOT / 'tests' / 'samples' / 'chat'
+sys.path.insert(0, str(CHAT_DIR))
+BOMBERMAN_DIR = Path(__file__).parent.resolve()
+sys.path.insert(0, str(BOMBERMAN_DIR))
+
+from Inspector import Inspector
+from Gateway import Gateway
+from BombermanServer import BombermanServer, ServerStopTimeout
+
+from client.goverseclient_python.client import Client, ClientOptions
+from samples.bomberman.proto import bomberman_pb2
+
+POSTGRES_HOST = "127.0.0.1"
+POSTGRES_PORT = 5432
+
+NUM_NODES = 3
+NUM_GATES = 2
+
+# Stress-mode match length: short enough that clients turn over many
+# matches per minute. The bomberman server reads this env var on
+# start (BombermanServer.py forwards it to the subprocess via
+# inheriting os.environ).
+DEFAULT_MATCH_TIME_LIMIT_TICKS = 50
+
+# Polling cadence on Player.GetStats while we wait for total_matches
+# to advance after a JoinQueue. Low frequency is fine — match end is
+# a slow event from the client's perspective.
+STATS_POLL_INTERVAL = 0.5
+# How long we'll wait for a single match to conclude before declaring
+# the cycle stuck. Generous: server-side time limit is 5 s by default
+# plus end-of-match RecordMatchResult retry budget (60 s) plus padding.
+MAX_MATCH_WAIT_SECONDS = 90.0
+
+# Inter-cycle pause so clients don't all hammer JoinQueue in lockstep.
+MIN_REJOIN_DELAY = 0.0
+MAX_REJOIN_DELAY = 0.5
+
+
+def ensure_postgres_ready() -> bool:
+    try:
+        with socket.create_connection((POSTGRES_HOST, POSTGRES_PORT), timeout=1.0):
+            pass
+    except OSError as e:
+        print(f"❌ Postgres not reachable at {POSTGRES_HOST}:{POSTGRES_PORT}: {e}")
+        print("   Local dev: run `docker compose up -d postgres`.")
+        print("   CI: ensure the workflow provisions Postgres before this step.")
+        return False
+    print(f"✅ Postgres reachable on {POSTGRES_HOST}:{POSTGRES_PORT}")
+    return True
+
+
+@dataclass
+class ClientStats:
+    cycles_completed: int = 0
+    rpc_errors: int = 0
+    timeouts: int = 0
+    invariant_violations: int = 0
+    final_total_matches: Optional[int] = None
+    final_wins: Optional[int] = None
+    final_losses: Optional[int] = None
+
+
+class StressClient:
+    """One stress-test client. Joins queue → waits for stat increment → repeats."""
+
+    def __init__(self, client_id: int, gate_port: int):
+        self.client_id = client_id
+        self.gate_port = gate_port
+        self.player_id = f"stress-player-{client_id:03d}"
+        self.client: Optional[Client] = None
+        self._thread: Optional[threading.Thread] = None
+        self.stats = ClientStats()
+
+    def connect(self) -> None:
+        self.client = Client([f"localhost:{self.gate_port}"], ClientOptions(call_timeout=15.0))
+        self.client.connect(timeout=10.0)
+
+    def close(self) -> None:
+        if self.client is not None:
+            try:
+                self.client.close()
+            except Exception:
+                pass
+            self.client = None
+
+    def start(self, stop_event: threading.Event) -> None:
+        self._thread = threading.Thread(target=self._run, args=(stop_event,), daemon=True)
+        self._thread.start()
+
+    def join(self, timeout: float = 30.0) -> None:
+        if self._thread is not None:
+            self._thread.join(timeout=timeout)
+
+    def _run(self, stop_event: threading.Event) -> None:
+        while not stop_event.is_set():
+            try:
+                self._one_cycle(stop_event)
+            except Exception as e:
+                self.stats.rpc_errors += 1
+                print(f"[client-{self.client_id}] cycle error: {e}")
+            time.sleep(random.uniform(MIN_REJOIN_DELAY, MAX_REJOIN_DELAY))
+
+    def _one_cycle(self, stop_event: threading.Event) -> None:
+        # Capture pre-join total_matches so we can detect the increment.
+        before = self._fetch_total_matches()
+        if before is None:
+            return  # transient: counted as rpc_error inside fetch
+
+        # Join the queue.
+        join_req = bomberman_pb2.JoinQueueRequest(
+            player_id=self.player_id, client_id=self.client.client_id
+        )
+        resp_any = self.client.call_object(
+            "MatchmakingQueue", "MatchmakingQueue", "JoinQueue", join_req, timeout=10.0
+        )
+        if resp_any is None:
+            self.stats.rpc_errors += 1
+            return
+        resp = bomberman_pb2.JoinQueueResponse()
+        resp_any.Unpack(resp)
+        if not resp.ok:
+            self.stats.rpc_errors += 1
+            print(f"[client-{self.client_id}] JoinQueue rejected: {resp.reason}")
+            return
+
+        # Wait for total_matches to advance — that's our "match ended"
+        # signal. Bounded by MAX_MATCH_WAIT_SECONDS so a stuck cycle
+        # surfaces as a timeout rather than hanging the whole run.
+        deadline = time.time() + MAX_MATCH_WAIT_SECONDS
+        while time.time() < deadline and not stop_event.is_set():
+            time.sleep(STATS_POLL_INTERVAL)
+            after = self._fetch_total_matches()
+            if after is None:
+                continue
+            if after > before:
+                # The killer invariant: exactly one increment per cycle.
+                # If reliable-call dedup is broken, the recordResults
+                # retry path could fire RecordMatchResult more than once
+                # and after - before would exceed 1.
+                if after - before != 1:
+                    self.stats.invariant_violations += 1
+                    print(
+                        f"[client-{self.client_id}] EXACTLY-ONCE VIOLATION: "
+                        f"player {self.player_id} total_matches jumped from {before} to {after} "
+                        f"after one JoinQueue cycle (expected +1)"
+                    )
+                self.stats.cycles_completed += 1
+                return
+        if not stop_event.is_set():
+            self.stats.timeouts += 1
+            print(f"[client-{self.client_id}] cycle timeout (waited {MAX_MATCH_WAIT_SECONDS}s)")
+
+    def _fetch_total_matches(self) -> Optional[int]:
+        if self.client is None:
+            return None
+        req = bomberman_pb2.GetPlayerStatsRequest()
+        try:
+            resp_any = self.client.call_object(
+                "Player", f"Player-{self.player_id}", "GetStats", req, timeout=5.0
+            )
+        except Exception as e:
+            self.stats.rpc_errors += 1
+            print(f"[client-{self.client_id}] GetStats failed: {e}")
+            return None
+        if resp_any is None:
+            return None
+        resp = bomberman_pb2.GetPlayerStatsResponse()
+        resp_any.Unpack(resp)
+        return int(resp.stats.total_matches)
+
+    def fetch_final_stats(self) -> None:
+        if self.client is None:
+            return
+        req = bomberman_pb2.GetPlayerStatsRequest()
+        try:
+            resp_any = self.client.call_object(
+                "Player", f"Player-{self.player_id}", "GetStats", req, timeout=5.0
+            )
+        except Exception as e:
+            print(f"[client-{self.client_id}] final GetStats failed: {e}")
+            return
+        if resp_any is None:
+            return
+        resp = bomberman_pb2.GetPlayerStatsResponse()
+        resp_any.Unpack(resp)
+        self.stats.final_total_matches = int(resp.stats.total_matches)
+        self.stats.final_wins = int(resp.stats.wins)
+        self.stats.final_losses = int(resp.stats.losses)
+
+
+def print_stats(clients: List[StressClient]) -> None:
+    cycles  = sum(c.stats.cycles_completed for c in clients)
+    errors  = sum(c.stats.rpc_errors for c in clients)
+    tos     = sum(c.stats.timeouts for c in clients)
+    viol    = sum(c.stats.invariant_violations for c in clients)
+    print(
+        f"\ncycles={cycles}  rpc_errors={errors}  "
+        f"timeouts={tos}  exactly_once_violations={viol}"
+    )
+
+
+def assert_invariants(clients: List[StressClient]) -> bool:
+    print("\n" + "=" * 80)
+    print("INVARIANT CHECK")
+    print("=" * 80)
+    failures = 0
+    for c in clients:
+        c.fetch_final_stats()
+        s = c.stats
+        if s.invariant_violations > 0:
+            print(f"❌ {c.player_id}: {s.invariant_violations} exactly-once violations during run")
+            failures += 1
+            continue
+        if s.cycles_completed == 0:
+            print(f"⚠️  {c.player_id}: never completed a cycle (errors={s.rpc_errors} timeouts={s.timeouts})")
+            # Not a hard failure — could be flake on a small run.
+            continue
+        if s.final_total_matches is None:
+            print(f"❌ {c.player_id}: could not fetch final stats")
+            failures += 1
+            continue
+        # Cycle accounting: each completed cycle should map to exactly
+        # one match in Player.total_matches.
+        if s.final_total_matches != s.cycles_completed:
+            print(
+                f"❌ {c.player_id}: cycles_completed={s.cycles_completed} but server "
+                f"total_matches={s.final_total_matches} (drift indicates double or missed credit)"
+            )
+            failures += 1
+            continue
+        # Data invariant from the proto: total_matches == wins + losses.
+        if s.final_total_matches != (s.final_wins or 0) + (s.final_losses or 0):
+            print(
+                f"❌ {c.player_id}: total_matches={s.final_total_matches} != "
+                f"wins({s.final_wins}) + losses({s.final_losses})"
+            )
+            failures += 1
+            continue
+        print(
+            f"✅ {c.player_id}: {s.cycles_completed} cycles, "
+            f"server total={s.final_total_matches} wins={s.final_wins} losses={s.final_losses}"
+        )
+    return failures == 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--duration", type=int, default=60)
+    parser.add_argument("--clients", type=int, default=8)
+    parser.add_argument("--config", default=str(BOMBERMAN_DIR / "stress_config.yml"))
+    parser.add_argument("--match-ticks", type=int, default=DEFAULT_MATCH_TIME_LIMIT_TICKS,
+                        help="Per-match tick limit. 50 = 5 s; 1800 = 3 min (production).")
+    args = parser.parse_args()
+
+    if not ensure_postgres_ready():
+        return 1
+
+    config_file = Path(args.config).resolve()
+    if not config_file.is_file():
+        print(f"❌ config file not found: {config_file}")
+        return 1
+
+    # Forward the short-match override into the bomberman server
+    # subprocess via the inherited environment.
+    os.environ["BOMBERMAN_MATCH_TIME_LIMIT_TICKS"] = str(args.match_ticks)
+
+    import yaml
+    with open(config_file) as f:
+        cfg = yaml.safe_load(f)
+    node_ids = [n["id"] for n in cfg["nodes"]][:NUM_NODES]
+    gate_ids = [g["id"] for g in cfg["gates"]][:NUM_GATES]
+    gate_ports = [int(g["grpc_addr"].rsplit(":", 1)[1]) for g in cfg["gates"]][:NUM_GATES]
+
+    inspector: Optional[Inspector] = None
+    servers: List[BombermanServer] = []
+    gateways: List[Gateway] = []
+    clients: List[StressClient] = []
+    stop_event = threading.Event()
+
+    shutting_down = False
+
+    def shutdown():
+        nonlocal shutting_down
+        if shutting_down:
+            return
+        shutting_down = True
+        print("\n--- SHUTDOWN ---")
+        stop_event.set()
+        for c in clients:
+            try:
+                c.join(timeout=10.0)
+            except Exception:
+                pass
+            c.close()
+        for gw in gateways:
+            try:
+                gw.close()
+            except Exception as e:
+                print(f"gateway close error: {e}")
+        for srv in servers:
+            try:
+                srv.close()
+            except ServerStopTimeout as e:
+                print(f"❌ {e}")
+            except Exception as e:
+                print(f"server close error: {e}")
+        if inspector is not None:
+            try:
+                inspector.close()
+            except Exception as e:
+                print(f"inspector close error: {e}")
+
+    def handle_signal(signum, frame):
+        shutdown()
+        sys.exit(1)
+
+    signal.signal(signal.SIGINT, handle_signal)
+    signal.signal(signal.SIGTERM, handle_signal)
+
+    try:
+        print("=" * 80)
+        print(f"STARTING CLUSTER (match_ticks={args.match_ticks})")
+        print("=" * 80)
+        inspector = Inspector(config_file=str(config_file))
+        inspector.start()
+        if not inspector.wait_for_ready(timeout=30):
+            print("❌ Inspector failed to start")
+            return 1
+
+        for i, node_id in enumerate(node_ids):
+            srv = BombermanServer(server_index=i, config_file=str(config_file), node_id=node_id)
+            srv.start()
+            servers.append(srv)
+        for srv in servers:
+            if not srv.wait_for_ready(timeout=30):
+                print(f"❌ {srv.name} failed to start")
+                return 1
+
+        time.sleep(5)
+
+        for gid in gate_ids:
+            gw = Gateway(config_file=str(config_file), gate_id=gid)
+            gw.start()
+            gateways.append(gw)
+
+        time.sleep(2)
+
+        print("\n" + "=" * 80)
+        print(f"LAUNCHING {args.clients} CLIENTS FOR {args.duration}s")
+        print("=" * 80)
+        for i in range(args.clients):
+            c = StressClient(i, gate_ports[i % len(gate_ports)])
+            c.connect()
+            clients.append(c)
+        for c in clients:
+            c.start(stop_event)
+
+        deadline = time.time() + args.duration
+        while time.time() < deadline:
+            time.sleep(5)
+            print_stats(clients)
+
+        stop_event.set()
+        for c in clients:
+            c.join(timeout=15.0)
+
+        print_stats(clients)
+
+        if not assert_invariants(clients):
+            print("\n❌ INVARIANT CHECK FAILED")
+            return 1
+        print("\n✅ bomberman stress test passed")
+        return 0
+    finally:
+        shutdown()
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Final PR in the bomberman series (5/5). Closes the loop with end-to-end correctness verification + onboarding docs + CI.

**Server change** — \`MatchTimeLimit\` becomes env-overridable (const → var read once from \`BOMBERMAN_MATCH_TIME_LIMIT_TICKS\`, default 1800 = 3 min). The stress driver sets it to 50 (= 5 s) so a 2-minute CI run turns over many matches.

**Sample additions** —
- \`stress_config.yml\` — 1 inspector + 3 nodes + 2 gates, Postgres + etcd, with \`MatchmakingQueue\` singleton declared in \`cluster.auto_load_objects\`.
- \`BombermanServer.py\` — thin subclass of \`samples/common/ServerProcess\`.
- \`stress_test.py\` (~340 LOC) — N concurrent clients, each running JoinQueue → wait-for-stat-increment → JoinQueue cycles.
- \`README.md\` — object model, local-run and browser-play instructions, file map.

**CI** — new \`bomberman-stress-test\` job modelled on \`wallet-stress-test\` (Postgres provisioning, schema init, 120 s × 8 clients, coverage upload).

## The killer invariant

Each JoinQueue cycle must increment the player's \`total_matches\` by **exactly 1**. The retry loop inside \`Match.recordResults\` keeps trying until the call lands, but the stable per-player \`call_id\` ensures it lands at most once. If reliable-call dedup regressed, \`total_matches\` would jump by ≥2 and the test fails.

## Test plan
- [x] \`go build ./samples/bomberman/...\`
- [x] \`go vet ./samples/bomberman/...\`
- [x] \`go test ./samples/bomberman/...\`
- [x] \`python3 -c '...'\` smoke test for proto + helper imports
- [ ] CI \`bomberman-stress-test\` job

🤖 Generated with [Claude Code](https://claude.com/claude-code)