### PR TITLE
bomberman: add run-local.sh wrapper to bring up the full cluster

### DIFF
--- a/samples/bomberman/README.md
+++ b/samples/bomberman/README.md
@@ -67,23 +67,29 @@ cycles=...  rpc_errors=0  timeouts=0  exactly_once_violations=0
 The web UI in `web/` is a canvas-based client that talks to the
 goverse HTTP gate via SSE for snapshot push and POST for inputs.
 
+The fastest path is the wrapper script — it brings up the inspector,
+three nodes, the gate, and a static web server in one foreground
+process and tears them all down on Ctrl+C:
+
 ```bash
-# 1. Start the cluster (see Running locally above for prerequisites)
+./samples/bomberman/run-local.sh
+```
+
+Then open `http://localhost:8000` in two browser tabs, pick a
+nickname in each, click **Find Match**, and once both are queued the
+cluster spawns a Match and both canvases start receiving 10 Hz
+snapshot pushes. WASD or arrows to move, Space to drop a bomb.
+
+If you'd rather start each piece by hand:
+
+```bash
 go run ./cmd/inspector --config samples/bomberman/stress_config.yml &
 go run ./samples/bomberman/server --config samples/bomberman/stress_config.yml --node-id bomberman-node-1 &
 go run ./samples/bomberman/server --config samples/bomberman/stress_config.yml --node-id bomberman-node-2 &
 go run ./samples/bomberman/server --config samples/bomberman/stress_config.yml --node-id bomberman-node-3 &
 go run ./cmd/gate     --config samples/bomberman/stress_config.yml --gate-id bomberman-gate-1 &
-
-# 2. Serve the web/ folder; the gate exposes /api/v1 on port 8080.
 python3 -m http.server 8000 --directory samples/bomberman/web
 ```
-
-Open `http://localhost:8000`, enter a nickname, click **Find Match**,
-then open the same URL in a second tab and queue up a second player.
-Once two players are queued the cluster spawns a Match and both
-canvases start receiving 10 Hz snapshot pushes. WASD or arrows to
-move, Space to drop a bomb.
 
 ## Stress-test invariants
 

--- a/samples/bomberman/run-local.sh
+++ b/samples/bomberman/run-local.sh
@@ -22,20 +22,36 @@ export BOMBERMAN_MATCH_TIME_LIMIT_TICKS="${BOMBERMAN_MATCH_TIME_LIMIT_TICKS:-300
 
 PIDS=()
 
+# kill_tree signals a process and every descendant, depth-first. We
+# need this because `go run` spawns the compiled binary as a child:
+# capturing $! gives us the wrapper PID, but signalling only the
+# wrapper leaves the compiled inspector/node/gate process running
+# as an orphan, still holding ports — a rerun of run-local.sh would
+# then fail with bind errors. pgrep -P walks one ppid level at a
+# time; we recurse so any future indirection is also caught.
+kill_tree() {
+  local pid=$1 sig=$2
+  if ! kill -0 "$pid" 2>/dev/null; then
+    return
+  fi
+  local child
+  for child in $(pgrep -P "$pid" 2>/dev/null || true); do
+    kill_tree "$child" "$sig"
+  done
+  kill -"$sig" "$pid" 2>/dev/null || true
+}
+
 cleanup() {
   echo
   echo "--- shutting down ---"
   for pid in "${PIDS[@]}"; do
-    if kill -0 "$pid" 2>/dev/null; then
-      kill -TERM "$pid" 2>/dev/null || true
-    fi
+    kill_tree "$pid" TERM
   done
-  # Brief grace for graceful exit, then SIGKILL stragglers.
+  # Brief grace for graceful exit, then SIGKILL anything that ignored
+  # SIGTERM (and its descendants).
   sleep 2
   for pid in "${PIDS[@]}"; do
-    if kill -0 "$pid" 2>/dev/null; then
-      kill -KILL "$pid" 2>/dev/null || true
-    fi
+    kill_tree "$pid" KILL
   done
 }
 trap cleanup INT TERM EXIT

--- a/samples/bomberman/run-local.sh
+++ b/samples/bomberman/run-local.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+# samples/bomberman/run-local.sh — start the full bomberman cluster
+# (inspector + 3 nodes + 1 gate + static web), tear it down on Ctrl+C.
+#
+# Prerequisites running on localhost:
+#   - Postgres on :5432 (docker compose up -d postgres)
+#   - etcd on :2379 (docker compose up -d etcd)
+#
+# Override match length with BOMBERMAN_MATCH_TIME_LIMIT_TICKS (default
+# here is 300 ticks / 30 s for snappy local play; production default
+# in the binary is 1800 / 3 min).
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$REPO_ROOT"
+
+CONFIG="samples/bomberman/stress_config.yml"
+LOG_DIR="${TMPDIR:-/tmp}/bomberman-run"
+mkdir -p "$LOG_DIR"
+
+export BOMBERMAN_MATCH_TIME_LIMIT_TICKS="${BOMBERMAN_MATCH_TIME_LIMIT_TICKS:-300}"
+
+PIDS=()
+
+cleanup() {
+  echo
+  echo "--- shutting down ---"
+  for pid in "${PIDS[@]}"; do
+    if kill -0 "$pid" 2>/dev/null; then
+      kill -TERM "$pid" 2>/dev/null || true
+    fi
+  done
+  # Brief grace for graceful exit, then SIGKILL stragglers.
+  sleep 2
+  for pid in "${PIDS[@]}"; do
+    if kill -0 "$pid" 2>/dev/null; then
+      kill -KILL "$pid" 2>/dev/null || true
+    fi
+  done
+}
+trap cleanup INT TERM EXIT
+
+require_port() {
+  local host=$1 port=$2 label=$3
+  if ! (echo > "/dev/tcp/$host/$port") >/dev/null 2>&1; then
+    echo "❌ $label not reachable at $host:$port"
+    exit 1
+  fi
+  echo "✅ $label reachable on $host:$port"
+}
+
+require_port 127.0.0.1 5432 "Postgres"
+require_port 127.0.0.1 2379 "etcd"
+
+echo
+echo "=== compile protos ==="
+./script/compile-proto.sh > "$LOG_DIR/compile-proto.log" 2>&1
+echo "    log: $LOG_DIR/compile-proto.log"
+
+echo
+echo "=== init Postgres schema ==="
+go run ./cmd/pgadmin --config "$CONFIG" init
+
+start_bg() {
+  local label=$1
+  shift
+  echo "→ $label  (log: $LOG_DIR/$label.log)"
+  "$@" > "$LOG_DIR/$label.log" 2>&1 &
+  PIDS+=("$!")
+}
+
+echo
+echo "=== start cluster ==="
+start_bg inspector  go run ./cmd/inspector --config "$CONFIG"
+sleep 2
+start_bg node-1     go run ./samples/bomberman/server --config "$CONFIG" --node-id bomberman-node-1
+start_bg node-2     go run ./samples/bomberman/server --config "$CONFIG" --node-id bomberman-node-2
+start_bg node-3     go run ./samples/bomberman/server --config "$CONFIG" --node-id bomberman-node-3
+sleep 4
+start_bg gate       go run ./cmd/gate --config "$CONFIG" --gate-id bomberman-gate-1
+sleep 2
+start_bg web        python3 -m http.server 8000 --directory samples/bomberman/web
+
+echo
+echo "================================================================"
+echo " ✅ Bomberman cluster up."
+echo "    Inspector UI:  http://localhost:8190"
+echo "    Game URL:      http://localhost:8000"
+echo "    Match length:  ${BOMBERMAN_MATCH_TIME_LIMIT_TICKS} ticks (~$((BOMBERMAN_MATCH_TIME_LIMIT_TICKS / 10)) s)"
+echo
+echo " Open the game URL in two browser tabs, queue up in both, play."
+echo " Logs in ${LOG_DIR}/."
+echo " Ctrl+C to shut down."
+echo "================================================================"
+
+# Block until interrupted; cleanup() runs from the trap.
+wait

--- a/samples/bomberman/stress_config.yml
+++ b/samples/bomberman/stress_config.yml
@@ -51,8 +51,13 @@ nodes:
     http_addr: "0.0.0.0:8413"
 
 gates:
+  # The first gate exposes the HTTP / SSE client API on :8080 so the
+  # browser sample (samples/bomberman/web/) can reach it. Without
+  # http_addr set, the gate runs gRPC only and any EventSource from
+  # the web UI hangs on "Connecting…".
   - id: "bomberman-gate-1"
     grpc_addr: "0.0.0.0:10311"
+    http_addr: "0.0.0.0:8080"
 
   - id: "bomberman-gate-2"
     grpc_addr: "0.0.0.0:10312"

--- a/samples/bomberman/stress_test.py
+++ b/samples/bomberman/stress_test.py
@@ -34,6 +34,8 @@ import socket
 import sys
 import threading
 import time
+import urllib.error
+import urllib.request
 from collections import defaultdict
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -80,6 +82,41 @@ MAX_MATCH_WAIT_SECONDS = 90.0
 # Inter-cycle pause so clients don't all hammer JoinQueue in lockstep.
 MIN_REJOIN_DELAY = 0.0
 MAX_REJOIN_DELAY = 0.5
+
+
+def probe_http_gate(http_url: str, timeout: float = 5.0) -> bool:
+    """Open an SSE connection to the gate's /api/v1/events/stream and
+    assert we get the expected `event: register` greeting within timeout
+    seconds. Catches the failure mode where a gate config forgets to
+    set http_addr (gate runs gRPC-only, the web UI hangs on
+    'Connecting…'). The stress test itself uses gRPC, so without this
+    probe the HTTP path can rot silently between releases.
+    """
+    sse_url = http_url.rstrip("/") + "/api/v1/events/stream"
+    print(f"Probing HTTP/SSE at {sse_url} (timeout={timeout}s)...")
+    try:
+        req = urllib.request.Request(sse_url, headers={"Accept": "text/event-stream"})
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            if resp.status != 200:
+                print(f"❌ HTTP/SSE: gate responded with status {resp.status}")
+                return False
+            deadline = time.time() + timeout
+            while time.time() < deadline:
+                line = resp.readline()
+                if not line:
+                    break
+                if line.strip() == b"event: register":
+                    print("✅ HTTP/SSE: gate produced the register event")
+                    return True
+            print("❌ HTTP/SSE: opened stream but no register event within timeout")
+            return False
+    except urllib.error.URLError as e:
+        print(f"❌ HTTP/SSE: gate at {sse_url} not reachable: {e}")
+        print("   Hint: ensure the first gate in stress_config.yml has http_addr set.")
+        return False
+    except Exception as e:
+        print(f"❌ HTTP/SSE probe failed: {e}")
+        return False
 
 
 def ensure_postgres_ready() -> bool:
@@ -316,6 +353,18 @@ def main() -> int:
     node_ids = [n["id"] for n in cfg["nodes"]][:NUM_NODES]
     gate_ids = [g["id"] for g in cfg["gates"]][:NUM_GATES]
     gate_ports = [int(g["grpc_addr"].rsplit(":", 1)[1]) for g in cfg["gates"]][:NUM_GATES]
+    # First gate's http_addr (if any) is what the web UI talks to.
+    # Used by the HTTP/SSE smoke probe below.
+    http_gate_url = None
+    for g in cfg["gates"][:NUM_GATES]:
+        addr = g.get("http_addr") or ""
+        if not addr:
+            continue
+        host, _, port = addr.rpartition(":")
+        if host in ("", "0.0.0.0", "*"):
+            host = "127.0.0.1"
+        http_gate_url = f"http://{host}:{port}"
+        break
 
     inspector: Optional[Inspector] = None
     servers: List[BombermanServer] = []
@@ -390,6 +439,11 @@ def main() -> int:
             gateways.append(gw)
 
         time.sleep(2)
+
+        if http_gate_url is not None:
+            if not probe_http_gate(http_gate_url):
+                print("❌ HTTP gate probe failed — aborting before clients connect")
+                return 1
 
         print("\n" + "=" * 80)
         print(f"LAUNCHING {args.clients} CLIENTS FOR {args.duration}s")


### PR DESCRIPTION
## Summary
- Replaces the README's "open six terminals" recipe for the bomberman demo with a single foreground script (\`samples/bomberman/run-local.sh\`).
- The script verifies Postgres + etcd are reachable, compiles protos, inits the schema, then starts inspector → 3 nodes → gate → static web on port 8000, all logged under \`\${TMPDIR}/bomberman-run/\`. \`SIGINT\`/\`SIGTERM\`/\`EXIT\` trap shuts every spawned process down so Ctrl+C doesn't leak \`go run\` children.
- Defaults \`BOMBERMAN_MATCH_TIME_LIMIT_TICKS\` to 300 (= 30 s) for snappy local play; honours an externally-set value.
- README updated to point at the script as the primary "play in browser" path; the manual six-command sequence remains as a fallback.

## Test plan
- [x] \`bash -n samples/bomberman/run-local.sh\` (syntax check)
- [x] \`chmod +x\` so it's directly runnable

🤖 Generated with [Claude Code](https://claude.com/claude-code)