### PR TITLE
gate: enforce CheckClientCreate on the HTTP CreateObject handler

### DIFF
--- a/gate/gateserver/http_access_test.go
+++ b/gate/gateserver/http_access_test.go
@@ -63,6 +63,46 @@ func TestHandleCallObject_AccessDeniedForRejectedMethod(t *testing.T) {
 	}
 }
 
+// TestHandleCreateObject_LifecycleRejected pins the gate's HTTP
+// handleCreateObject lifecycle check. Mirrors what the gRPC
+// CreateObject handler does (gateserver.go:CreateObject). Without the
+// gate-side check, an INTERNAL/REJECT lifecycle rule would only be
+// enforced for streaming-gRPC clients; a browser POST would slip
+// past validation.
+func TestHandleCreateObject_LifecycleRejected(t *testing.T) {
+	rules := []config.LifecycleRule{
+		// Mark Restricted CREATE as INTERNAL — only nodes may create.
+		{Type: "Restricted", Lifecycle: "CREATE", Access: "INTERNAL"},
+	}
+	validator, err := config.NewLifecycleValidator(rules)
+	if err != nil {
+		t.Fatalf("NewLifecycleValidator: %v", err)
+	}
+
+	s := &GateServer{
+		logger:             logger.NewLogger("test-gate"),
+		lifecycleValidator: validator,
+	}
+
+	req := httptest.NewRequest(http.MethodPost,
+		"/api/v1/objects/create/Restricted/some-id", nil)
+	w := httptest.NewRecorder()
+
+	s.handleCreateObject(w, req)
+
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("status = %d; want 403 Forbidden", w.Code)
+	}
+	respBody, _ := io.ReadAll(w.Body)
+	var errResp HTTPErrorResponse
+	if err := json.Unmarshal(respBody, &errResp); err != nil {
+		t.Fatalf("decode error response: %v\nbody=%s", err, string(respBody))
+	}
+	if errResp.Code != "ACCESS_DENIED" {
+		t.Fatalf("error code = %q; want ACCESS_DENIED. body=%s", errResp.Code, string(respBody))
+	}
+}
+
 // TestHandleCallObject_AllowsExternalClients confirms the access
 // check doesn't block legitimate ALLOW / EXTERNAL methods. Without
 // a real cluster the call still fails downstream, but the failure

--- a/gate/gateserver/http_handler.go
+++ b/gate/gateserver/http_handler.go
@@ -245,6 +245,20 @@ func (s *GateServer) handleCreateObject(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
+	// Mirror the gRPC CreateObject handler's lifecycle check
+	// (gateserver.go:CreateObject). Without this, an INTERNAL or
+	// REJECT lifecycle rule would only be enforced for streaming-gRPC
+	// clients — a browser POSTing here would slip past gate-side
+	// validation and the receiving node would honour the request as
+	// a node-to-node create, defeating the rule.
+	if s.lifecycleValidator != nil {
+		if err := s.lifecycleValidator.CheckClientCreate(objType, objID); err != nil {
+			s.logger.Warnf("Create denied for HTTP client: type=%s, id=%s: %v", objType, objID, err)
+			s.writeError(w, http.StatusForbidden, "ACCESS_DENIED", err.Error())
+			return
+		}
+	}
+
 	// Create context
 	ctx := r.Context()
 


### PR DESCRIPTION
## Summary

Follow-up to PR #548. Closes one of two remaining gate-side validation gaps:

- **CreateObject (HTTP)** — fixed here. Mirrors the gRPC sibling's existing \`CheckClientCreate\` so an INTERNAL or REJECT lifecycle rule is enforced regardless of transport.
- **DeleteObject** — **not** fixed; explained below.

## Why DeleteObject is left for later

The DeleteObject wire protocol — gRPC \`DeleteObjectRequest{id string}\` and HTTP \`POST /api/v1/objects/delete/{id}\` — carries only an object id, no type. \`LifecycleValidator.CheckClientDelete(type, id)\` needs both. To plumb the gate-side check we'd need one of:

1. Add \`type\` to the wire protocol (extending the API)
2. A gate→node lookup roundtrip per delete to fetch the type
3. A "from-client" flag on the internal delete RPC so the node can run \`CheckClientDelete\` instead of \`CheckNodeDelete\`

None are mechanical; #3 is probably the right answer but warrants a design pass on its own. Until then, DELETE is enforced only at the node via \`CheckNodeDelete\` (node.go:825), which means a client \`DeleteObject\` call routed through the cluster is treated as a node-to-node hop and gets the INTERNAL pass.

## Test plan
- [x] \`go test ./gate/gateserver/...\` — full suite green; new \`TestHandleCreateObject_LifecycleRejected\` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)