### PR TITLE
gate: enforce CheckClientDelete on the DeleteObject handlers

### DIFF
--- a/client/goverseclient/client.go
+++ b/client/goverseclient/client.go
@@ -603,8 +603,11 @@ func (c *Client) CreateObject(ctx context.Context, objectType, objectID string) 
 	return resp.Id, nil
 }
 
-// DeleteObject deletes an object by its ID.
-func (c *Client) DeleteObject(ctx context.Context, objectID string) error {
+// DeleteObject deletes an object by type + ID. The type is required so
+// the gate can run its CheckClientDelete lifecycle check; passing an
+// empty type currently logs a warning gate-side and skips the check
+// (v0.1 compat) but will be rejected outright in v0.3.
+func (c *Client) DeleteObject(ctx context.Context, objectType, objectID string) error {
 	c.mu.RLock()
 	if c.closed {
 		c.mu.RUnlock()
@@ -625,7 +628,8 @@ func (c *Client) DeleteObject(ctx context.Context, objectID string) error {
 	}
 
 	req := &gate_pb.DeleteObjectRequest{
-		Id: objectID,
+		Type: objectType,
+		Id:   objectID,
 	}
 
 	_, err := client.DeleteObject(ctx, req)

--- a/client/goverseclient/client.go
+++ b/client/goverseclient/client.go
@@ -603,10 +603,11 @@ func (c *Client) CreateObject(ctx context.Context, objectType, objectID string) 
 	return resp.Id, nil
 }
 
-// DeleteObject deletes an object by type + ID. The type is required so
-// the gate can run its CheckClientDelete lifecycle check; passing an
-// empty type currently logs a warning gate-side and skips the check
-// (v0.1 compat) but will be rejected outright in v0.3.
+// DeleteObject deletes an object by type + ID. The type is required:
+// the gate runs an advisory CheckClientDelete on it before forwarding.
+// The receiving node performs the authoritative authorization against
+// the object's real type — a mismatched claimed type is rejected
+// there.
 func (c *Client) DeleteObject(ctx context.Context, objectType, objectID string) error {
 	c.mu.RLock()
 	if c.closed {

--- a/client/goverseclient/client_integration_test.go
+++ b/client/goverseclient/client_integration_test.go
@@ -383,7 +383,7 @@ func TestClientIntegration(t *testing.T) {
 		t.Logf("Created object %s", objID)
 
 		// Delete the object via the client
-		err = client.DeleteObject(ctx, objID)
+		err = client.DeleteObject(ctx, "TestIntegrationObject", objID)
 		if err != nil {
 			t.Fatalf("DeleteObject failed: %v", err)
 		}
@@ -420,7 +420,7 @@ func TestClientIntegration(t *testing.T) {
 		t.Logf("Called Echo: %s", echoResp.Fields["message"].GetStringValue())
 
 		// Delete
-		err = client.DeleteObject(ctx, objID)
+		err = client.DeleteObject(ctx, "TestIntegrationObject", objID)
 		if err != nil {
 			t.Fatalf("DeleteObject failed: %v", err)
 		}
@@ -606,7 +606,7 @@ func TestClientIntegrationMultipleGates(t *testing.T) {
 			objID, echoResp.Fields["message"].GetStringValue())
 
 		// Delete the object via client 2
-		err = client2.DeleteObject(ctx, objID)
+		err = client2.DeleteObject(ctx, "TestIntegrationObject", objID)
 		if err != nil {
 			t.Fatalf("DeleteObject via client 2 failed: %v", err)
 		}

--- a/client/goverseclient/client_test.go
+++ b/client/goverseclient/client_test.go
@@ -164,7 +164,7 @@ func TestClientClose(t *testing.T) {
 		t.Errorf("CreateObject() after close error = %v, want %v", err, ErrClientClosed)
 	}
 
-	err = client.DeleteObject(ctx, "ID")
+	err = client.DeleteObject(ctx, "Type", "ID")
 	if err != ErrClientClosed {
 		t.Errorf("DeleteObject() after close error = %v, want %v", err, ErrClientClosed)
 	}
@@ -189,7 +189,7 @@ func TestClientNotConnected(t *testing.T) {
 		t.Errorf("CreateObject() when not connected error = %v, want %v", err, ErrNotConnected)
 	}
 
-	err = client.DeleteObject(ctx, "ID")
+	err = client.DeleteObject(ctx, "Type", "ID")
 	if err != ErrNotConnected {
 		t.Errorf("DeleteObject() when not connected error = %v, want %v", err, ErrNotConnected)
 	}

--- a/client/goverseclient_python/README.md
+++ b/client/goverseclient_python/README.md
@@ -56,7 +56,7 @@ response_any.Unpack(response)
 print(f"Counter value: {response.value}")
 
 # Delete the object
-client.delete_object("Counter-myid")
+client.delete_object("Counter", "Counter-myid")
 
 # Close the client
 client.close()
@@ -85,7 +85,7 @@ Client(addresses: List[str], options: Optional[ClientOptions] = None)
 - `reconnect(timeout: Optional[float] = None)` - Reconnect to a gate server
 - `wait_for_connection(timeout: float = 30.0)` - Wait until connected or timeout
 - `create_object(object_type: str, object_id: str, timeout: Optional[float] = None) -> str` - Create a new object
-- `delete_object(object_id: str, timeout: Optional[float] = None)` - Delete an object
+- `delete_object(object_type: str, object_id: str, timeout: Optional[float] = None)` - Delete an object
 - `call_object(object_type: str, object_id: str, method: str, request: Optional[Message] = None, timeout: Optional[float] = None) -> Optional[Any]` - Call a method on an object
 - `call_object_any(object_type: str, object_id: str, method: str, request: Optional[Any] = None, timeout: Optional[float] = None) -> Optional[Any]` - Call a method using protobuf Any directly
 

--- a/client/goverseclient_python/__init__.py
+++ b/client/goverseclient_python/__init__.py
@@ -23,7 +23,7 @@ Example usage:
     response = client.call_object("Counter", "Counter-myid", "Increment", request)
 
     # Delete the object
-    client.delete_object("Counter-myid")
+    client.delete_object("Counter", "Counter-myid")
 
     # Close the client
     client.close()

--- a/client/goverseclient_python/client.py
+++ b/client/goverseclient_python/client.py
@@ -665,12 +665,19 @@ class Client:
 
     def delete_object(
         self,
+        object_type: str,
         object_id: str,
         timeout: Optional[float] = None,
     ) -> None:
-        """Delete an object by its ID.
+        """Delete an object by type + ID.
+
+        The type is required so the gate can run its CheckClientDelete
+        lifecycle check. Passing an empty string currently logs a warning
+        on the gate and skips the check (v0.1 compat) but will be
+        rejected outright in v0.3.
 
         Args:
+            object_type: The type of the object to delete.
             object_id: The ID of the object to delete.
             timeout: Call timeout in seconds. If None, uses the default.
 
@@ -688,7 +695,7 @@ class Client:
 
         timeout = timeout or self._options.call_timeout
 
-        req = gate_pb2.DeleteObjectRequest(id=object_id)
+        req = gate_pb2.DeleteObjectRequest(type=object_type, id=object_id)
 
         stub.DeleteObject(req, timeout=timeout)
 

--- a/client/goverseclient_python/client.py
+++ b/client/goverseclient_python/client.py
@@ -671,10 +671,10 @@ class Client:
     ) -> None:
         """Delete an object by type + ID.
 
-        The type is required so the gate can run its CheckClientDelete
-        lifecycle check. Passing an empty string currently logs a warning
-        on the gate and skips the check (v0.1 compat) but will be
-        rejected outright in v0.3.
+        The type is required: the gate runs an advisory
+        CheckClientDelete on it before forwarding. The receiving node
+        performs the authoritative authorization against the object's
+        real type — a mismatched claimed type is rejected there.
 
         Args:
             object_type: The type of the object to delete.

--- a/client/goverseclient_python/tests/test_client.py
+++ b/client/goverseclient_python/tests/test_client.py
@@ -175,7 +175,7 @@ class TestClientClose(unittest.TestCase):
             client.create_object("Type", "ID")
 
         with self.assertRaises(ClientClosedError):
-            client.delete_object("ID")
+            client.delete_object("Type", "ID")
 
         with self.assertRaises(ClientClosedError):
             client.call_object_any("Type", "ID", "Method")
@@ -202,7 +202,7 @@ class TestClientNotConnected(unittest.TestCase):
             client.create_object("Type", "ID")
 
         with self.assertRaises(NotConnectedError):
-            client.delete_object("ID")
+            client.delete_object("Type", "ID")
 
         with self.assertRaises(NotConnectedError):
             client.call_object_any("Type", "ID", "Method")

--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -775,31 +775,45 @@ func (c *Cluster) CreateObject(ctx context.Context, objType, objID string) (resu
 	}
 }
 
-// DeleteObject deletes an object from the cluster (node-internal
-// callers). It determines which node hosts the object and routes the
-// deletion request accordingly. For gates, the deletion is performed
-// synchronously; for nodes, asynchronously to prevent deadlocks when
-// called from within object methods.
+// DeleteObject deletes an object from the cluster on behalf of a
+// node-internal caller (object-to-object, runtime cleanup). It runs
+// CheckNodeDelete on the supplied type, then routes the deletion to
+// whichever node hosts the object. For gates the deletion is
+// performed synchronously; for nodes asynchronously to prevent
+// deadlocks when called from within object methods.
 //
-// For gate-originated client deletions use DeleteClientObject — the
-// receiving node uses the claimed type to verify against the
-// object's real type, closing the spoof gap.
-func (c *Cluster) DeleteObject(ctx context.Context, objID string) error {
-	return c.deleteObjectImpl(ctx, objID, "" /* claimedType */)
+// Gate-originated client deletions go through DeleteClientObject
+// instead; the gate has its own CheckClientDelete authorization and
+// must not be re-checked with node semantics here (that would
+// incorrectly block EXTERNAL DELETE rules).
+func (c *Cluster) DeleteObject(ctx context.Context, objType, objID string) error {
+	if objType == "" {
+		return fmt.Errorf("DeleteObject requires a non-empty type")
+	}
+	if c.node != nil {
+		if validator := c.node.LifecycleValidator(); validator != nil {
+			if err := validator.CheckNodeDelete(objType, objID); err != nil {
+				c.logger.Warnf("%s - Delete denied by lifecycle rules: type=%s, id=%s: %v", c, objType, objID, err)
+				return fmt.Errorf("delete denied for %s/%s", objType, objID)
+			}
+		}
+	}
+	return c.deleteObjectImpl(ctx, objType, objID)
 }
 
 // DeleteClientObject is the gate-originated counterpart to
-// DeleteObject. claimedType is the type the gate received from the
-// client; the receiving node verifies it matches the object's real
-// type and rejects mismatches.
+// DeleteObject. The gate has already run CheckClientDelete on the
+// client-supplied type, so this layer skips the lifecycle check and
+// only forwards. The receiving node verifies the claimed type
+// against the object's real type, closing the spoof gap.
 func (c *Cluster) DeleteClientObject(ctx context.Context, claimedType, objID string) error {
 	if claimedType == "" {
 		return fmt.Errorf("DeleteClientObject requires a non-empty claimed type")
 	}
-	return c.deleteObjectImpl(ctx, objID, claimedType)
+	return c.deleteObjectImpl(ctx, claimedType, objID)
 }
 
-func (c *Cluster) deleteObjectImpl(ctx context.Context, objID, claimedType string) (err error) {
+func (c *Cluster) deleteObjectImpl(ctx context.Context, objType, objID string) (err error) {
 	start := time.Now()
 	defer func() { recordOperationResult(c.getAdvertiseAddr(), "DeleteObject", start, err) }()
 
@@ -824,15 +838,8 @@ func (c *Cluster) deleteObjectImpl(ctx context.Context, objID, claimedType strin
 		go func() {
 			asyncCtx, asyncCancel := context.WithTimeout(liveCtx, effectiveTimeout(c.config.DefaultDeleteTimeout, DefaultDeleteTimeout))
 			defer asyncCancel()
-			// Delete locally
-			c.logger.Infof("%s - Async deleting object %s locally (claimedType=%q)", c, objID, claimedType)
-			var localErr error
-			if claimedType != "" {
-				localErr = c.node.DeleteClientObject(asyncCtx, claimedType, objID)
-			} else {
-				localErr = c.node.DeleteObject(asyncCtx, objID)
-			}
-			if localErr != nil {
+			c.logger.Infof("%s - Async deleting object %s locally (type=%s)", c, objID, objType)
+			if localErr := c.node.DeleteObject(asyncCtx, objType, objID); localErr != nil {
 				c.logger.Errorf("%s - Async DeleteObject %s failed: %v", c, objID, localErr)
 			} else {
 				c.logger.Debugf("%s - Async DeleteObject %s completed successfully", c, objID)
@@ -843,7 +850,7 @@ func (c *Cluster) deleteObjectImpl(ctx context.Context, objID, claimedType strin
 	}
 
 	// Route to the appropriate node
-	c.logger.Infof("%s - Routing DeleteObject for %s to node %s (claimedType=%q)", c, objID, nodeAddr, claimedType)
+	c.logger.Infof("%s - Routing DeleteObject for %s to node %s (type=%s)", c, objID, nodeAddr, objType)
 
 	client, err := c.nodeConnections.GetConnection(nodeAddr)
 	if err != nil {
@@ -857,7 +864,7 @@ func (c *Cluster) deleteObjectImpl(ctx context.Context, objID, claimedType strin
 	// For nodes, execute asynchronously to prevent deadlocks when called from within object methods
 	req := &goverse_pb.DeleteObjectRequest{
 		Id:   objID,
-		Type: claimedType,
+		Type: objType,
 	}
 	if c.isGate() {
 		// Synchronous execution for gates

--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -787,25 +787,21 @@ func (c *Cluster) CreateObject(ctx context.Context, objType, objID string) (resu
 // deletes is the gate's responsibility (CheckClientDelete) before
 // this routing layer is invoked.
 func (c *Cluster) DeleteObject(ctx context.Context, objType, objID string) (err error) {
+	start := time.Now()
+	defer func() { recordOperationResult(c.getAdvertiseAddr(), "DeleteObject", start, err) }()
+
 	if objType == "" {
 		return fmt.Errorf("DeleteObject requires a non-empty type")
 	}
-	return c.deleteObjectImpl(ctx, objType, objID)
-}
-
-func (c *Cluster) deleteObjectImpl(ctx context.Context, objType, objID string) (err error) {
-	start := time.Now()
-	defer func() { recordOperationResult(c.getAdvertiseAddr(), "DeleteObject", start, err) }()
+	if objID == "" {
+		return fmt.Errorf("object ID must be specified")
+	}
 
 	// Enforce default delete timeout for synchronous operations in this function.
 	// Async goroutines create their own timeout context because this one is
 	// cancelled by defer when the function returns.
 	ctx, cancel := context.WithTimeout(ctx, effectiveTimeout(c.config.DefaultDeleteTimeout, DefaultDeleteTimeout))
 	defer cancel()
-
-	if objID == "" {
-		return fmt.Errorf("object ID must be specified")
-	}
 
 	// Determine which node hosts this object
 	nodeAddr, err := c.GetCurrentNodeForObject(ctx, objID)

--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -775,42 +775,22 @@ func (c *Cluster) CreateObject(ctx context.Context, objType, objID string) (resu
 	}
 }
 
-// DeleteObject deletes an object from the cluster on behalf of a
-// node-internal caller (object-to-object, runtime cleanup). It runs
-// CheckNodeDelete on the supplied type, then routes the deletion to
-// whichever node hosts the object. For gates the deletion is
-// performed synchronously; for nodes asynchronously to prevent
-// deadlocks when called from within object methods.
+// DeleteObject deletes an object from the cluster. It determines
+// which node hosts the object and routes the deletion request
+// accordingly. For gates the deletion is performed synchronously;
+// for nodes asynchronously to prevent deadlocks when called from
+// within object methods.
 //
-// Gate-originated client deletions go through DeleteClientObject
-// instead; the gate has its own CheckClientDelete authorization and
-// must not be re-checked with node semantics here (that would
-// incorrectly block EXTERNAL DELETE rules).
-func (c *Cluster) DeleteObject(ctx context.Context, objType, objID string) error {
+// objType is forwarded to the receiving node, which verifies it
+// matches the object's real type (rejecting spoofed claims) and
+// then runs CheckNodeDelete. Authorization for client-originated
+// deletes is the gate's responsibility (CheckClientDelete) before
+// this routing layer is invoked.
+func (c *Cluster) DeleteObject(ctx context.Context, objType, objID string) (err error) {
 	if objType == "" {
 		return fmt.Errorf("DeleteObject requires a non-empty type")
 	}
-	if c.node != nil {
-		if validator := c.node.LifecycleValidator(); validator != nil {
-			if err := validator.CheckNodeDelete(objType, objID); err != nil {
-				c.logger.Warnf("%s - Delete denied by lifecycle rules: type=%s, id=%s: %v", c, objType, objID, err)
-				return fmt.Errorf("delete denied for %s/%s", objType, objID)
-			}
-		}
-	}
 	return c.deleteObjectImpl(ctx, objType, objID)
-}
-
-// DeleteClientObject is the gate-originated counterpart to
-// DeleteObject. The gate has already run CheckClientDelete on the
-// client-supplied type, so this layer skips the lifecycle check and
-// only forwards. The receiving node verifies the claimed type
-// against the object's real type, closing the spoof gap.
-func (c *Cluster) DeleteClientObject(ctx context.Context, claimedType, objID string) error {
-	if claimedType == "" {
-		return fmt.Errorf("DeleteClientObject requires a non-empty claimed type")
-	}
-	return c.deleteObjectImpl(ctx, claimedType, objID)
 }
 
 func (c *Cluster) deleteObjectImpl(ctx context.Context, objType, objID string) (err error) {

--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -775,11 +775,29 @@ func (c *Cluster) CreateObject(ctx context.Context, objType, objID string) (resu
 	}
 }
 
-// DeleteObject deletes an object from the cluster.
-// It determines which node hosts the object and routes the deletion request accordingly.
-// For gates, the deletion is performed synchronously. For nodes, it is performed
-// asynchronously to prevent deadlocks when called from within object methods.
-func (c *Cluster) DeleteObject(ctx context.Context, objID string) (err error) {
+// DeleteObject deletes an object from the cluster (node-internal
+// callers). It determines which node hosts the object and routes the
+// deletion request accordingly. For gates, the deletion is performed
+// synchronously; for nodes, asynchronously to prevent deadlocks when
+// called from within object methods.
+//
+// For gate-originated client deletions use DeleteClientObject — the
+// receiving node uses that signal to pick CheckClientDelete vs
+// CheckNodeDelete on the object's real type.
+func (c *Cluster) DeleteObject(ctx context.Context, objID string) error {
+	return c.deleteObjectImpl(ctx, objID, false /* fromClient */)
+}
+
+// DeleteClientObject is the gate-originated counterpart to
+// DeleteObject. It tags the inter-node delete RPC with from_client=true
+// so the receiving node authorizes against CheckClientDelete using
+// the object's actual type, closing the spoof gap where a client
+// could claim an allowed type to bypass an INTERNAL/REJECT rule.
+func (c *Cluster) DeleteClientObject(ctx context.Context, objID string) error {
+	return c.deleteObjectImpl(ctx, objID, true /* fromClient */)
+}
+
+func (c *Cluster) deleteObjectImpl(ctx context.Context, objID string, fromClient bool) (err error) {
 	start := time.Now()
 	defer func() { recordOperationResult(c.getAdvertiseAddr(), "DeleteObject", start, err) }()
 
@@ -805,10 +823,15 @@ func (c *Cluster) DeleteObject(ctx context.Context, objID string) (err error) {
 			asyncCtx, asyncCancel := context.WithTimeout(liveCtx, effectiveTimeout(c.config.DefaultDeleteTimeout, DefaultDeleteTimeout))
 			defer asyncCancel()
 			// Delete locally
-			c.logger.Infof("%s - Async deleting object %s locally", c, objID)
-			err := c.node.DeleteObject(asyncCtx, objID)
-			if err != nil {
-				c.logger.Errorf("%s - Async DeleteObject %s failed: %v", c, objID, err)
+			c.logger.Infof("%s - Async deleting object %s locally (fromClient=%v)", c, objID, fromClient)
+			var localErr error
+			if fromClient {
+				localErr = c.node.DeleteClientObject(asyncCtx, objID)
+			} else {
+				localErr = c.node.DeleteObject(asyncCtx, objID)
+			}
+			if localErr != nil {
+				c.logger.Errorf("%s - Async DeleteObject %s failed: %v", c, objID, localErr)
 			} else {
 				c.logger.Debugf("%s - Async DeleteObject %s completed successfully", c, objID)
 				// Metrics are not recorded here since we don't track object types
@@ -818,7 +841,7 @@ func (c *Cluster) DeleteObject(ctx context.Context, objID string) (err error) {
 	}
 
 	// Route to the appropriate node
-	c.logger.Infof("%s - Routing DeleteObject for %s to node %s", c, objID, nodeAddr)
+	c.logger.Infof("%s - Routing DeleteObject for %s to node %s (fromClient=%v)", c, objID, nodeAddr, fromClient)
 
 	client, err := c.nodeConnections.GetConnection(nodeAddr)
 	if err != nil {
@@ -831,7 +854,8 @@ func (c *Cluster) DeleteObject(ctx context.Context, objID string) (err error) {
 	// (gates don't host objects so they don't hold object locks)
 	// For nodes, execute asynchronously to prevent deadlocks when called from within object methods
 	req := &goverse_pb.DeleteObjectRequest{
-		Id: objID,
+		Id:         objID,
+		FromClient: fromClient,
 	}
 	if c.isGate() {
 		// Synchronous execution for gates

--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -782,22 +782,24 @@ func (c *Cluster) CreateObject(ctx context.Context, objType, objID string) (resu
 // called from within object methods.
 //
 // For gate-originated client deletions use DeleteClientObject — the
-// receiving node uses that signal to pick CheckClientDelete vs
-// CheckNodeDelete on the object's real type.
+// receiving node uses the claimed type to verify against the
+// object's real type, closing the spoof gap.
 func (c *Cluster) DeleteObject(ctx context.Context, objID string) error {
-	return c.deleteObjectImpl(ctx, objID, false /* fromClient */)
+	return c.deleteObjectImpl(ctx, objID, "" /* claimedType */)
 }
 
 // DeleteClientObject is the gate-originated counterpart to
-// DeleteObject. It tags the inter-node delete RPC with from_client=true
-// so the receiving node authorizes against CheckClientDelete using
-// the object's actual type, closing the spoof gap where a client
-// could claim an allowed type to bypass an INTERNAL/REJECT rule.
-func (c *Cluster) DeleteClientObject(ctx context.Context, objID string) error {
-	return c.deleteObjectImpl(ctx, objID, true /* fromClient */)
+// DeleteObject. claimedType is the type the gate received from the
+// client; the receiving node verifies it matches the object's real
+// type and rejects mismatches.
+func (c *Cluster) DeleteClientObject(ctx context.Context, claimedType, objID string) error {
+	if claimedType == "" {
+		return fmt.Errorf("DeleteClientObject requires a non-empty claimed type")
+	}
+	return c.deleteObjectImpl(ctx, objID, claimedType)
 }
 
-func (c *Cluster) deleteObjectImpl(ctx context.Context, objID string, fromClient bool) (err error) {
+func (c *Cluster) deleteObjectImpl(ctx context.Context, objID, claimedType string) (err error) {
 	start := time.Now()
 	defer func() { recordOperationResult(c.getAdvertiseAddr(), "DeleteObject", start, err) }()
 
@@ -823,10 +825,10 @@ func (c *Cluster) deleteObjectImpl(ctx context.Context, objID string, fromClient
 			asyncCtx, asyncCancel := context.WithTimeout(liveCtx, effectiveTimeout(c.config.DefaultDeleteTimeout, DefaultDeleteTimeout))
 			defer asyncCancel()
 			// Delete locally
-			c.logger.Infof("%s - Async deleting object %s locally (fromClient=%v)", c, objID, fromClient)
+			c.logger.Infof("%s - Async deleting object %s locally (claimedType=%q)", c, objID, claimedType)
 			var localErr error
-			if fromClient {
-				localErr = c.node.DeleteClientObject(asyncCtx, objID)
+			if claimedType != "" {
+				localErr = c.node.DeleteClientObject(asyncCtx, claimedType, objID)
 			} else {
 				localErr = c.node.DeleteObject(asyncCtx, objID)
 			}
@@ -841,7 +843,7 @@ func (c *Cluster) deleteObjectImpl(ctx context.Context, objID string, fromClient
 	}
 
 	// Route to the appropriate node
-	c.logger.Infof("%s - Routing DeleteObject for %s to node %s (fromClient=%v)", c, objID, nodeAddr, fromClient)
+	c.logger.Infof("%s - Routing DeleteObject for %s to node %s (claimedType=%q)", c, objID, nodeAddr, claimedType)
 
 	client, err := c.nodeConnections.GetConnection(nodeAddr)
 	if err != nil {
@@ -854,8 +856,8 @@ func (c *Cluster) deleteObjectImpl(ctx context.Context, objID string, fromClient
 	// (gates don't host objects so they don't hold object locks)
 	// For nodes, execute asynchronously to prevent deadlocks when called from within object methods
 	req := &goverse_pb.DeleteObjectRequest{
-		Id:         objID,
-		FromClient: fromClient,
+		Id:   objID,
+		Type: claimedType,
 	}
 	if c.isGate() {
 		// Synchronous execution for gates

--- a/cluster/cluster_async_operations_test.go
+++ b/cluster/cluster_async_operations_test.go
@@ -225,7 +225,7 @@ func TestAsyncOperationsReturnImmediately(t *testing.T) {
 
 	// Measure time for DeleteObject to return
 	start = time.Now()
-	err = cluster1.DeleteObject(ctx, objID)
+	err = cluster1.DeleteObject(ctx, "AsyncTestObject", objID)
 	duration = time.Since(start)
 
 	if err != nil {
@@ -259,7 +259,7 @@ func (o *AsyncTestObject) CreateAnotherObject(ctx context.Context, req *goverse_
 // DeleteAnotherObject deletes another object from within a method
 func (o *AsyncTestObject) DeleteAnotherObject(ctx context.Context, req *goverse_pb.Empty) (*goverse_pb.Empty, error) {
 	// This call should not deadlock because DeleteObject is async
-	err := This().DeleteObject(ctx, "async-delete-obj-2")
+	err := This().DeleteObject(ctx, "AsyncTestObject", "async-delete-obj-2")
 	if err != nil {
 		return nil, err
 	}

--- a/cluster/cluster_gate_node_createobject_integration_test.go
+++ b/cluster/cluster_gate_node_createobject_integration_test.go
@@ -492,7 +492,7 @@ func TestGateNodeIntegration(t *testing.T) {
 		t.Logf("Verified object %s exists on node before deletion", objID)
 
 		// Delete the object via the gate cluster
-		err = gateCluster.DeleteObject(ctx, objID)
+		err = gateCluster.DeleteClientObject(ctx, "TestGateNodeObject", objID)
 		if err != nil {
 			t.Fatalf("DeleteObject via gate failed for %s: %v", objID, err)
 		}
@@ -524,7 +524,7 @@ func TestGateNodeIntegration(t *testing.T) {
 
 		// Delete all objects
 		for _, objID := range objectIDs {
-			err := gateCluster.DeleteObject(ctx, objID)
+			err := gateCluster.DeleteClientObject(ctx, "TestGateNodeObject", objID)
 			if err != nil {
 				t.Fatalf("DeleteObject via gate failed for %s: %v", objID, err)
 			}
@@ -576,7 +576,7 @@ func TestGateNodeIntegration(t *testing.T) {
 		t.Logf("Object %s has state: callCount=%d", objID, incResult)
 
 		// Delete the object
-		err = gateCluster.DeleteObject(ctx, objID)
+		err = gateCluster.DeleteClientObject(ctx, "TestGateNodeObject", objID)
 		if err != nil {
 			t.Fatalf("DeleteObject via gate failed for %s: %v", objID, err)
 		}

--- a/cluster/cluster_gate_node_createobject_integration_test.go
+++ b/cluster/cluster_gate_node_createobject_integration_test.go
@@ -492,7 +492,7 @@ func TestGateNodeIntegration(t *testing.T) {
 		t.Logf("Verified object %s exists on node before deletion", objID)
 
 		// Delete the object via the gate cluster
-		err = gateCluster.DeleteClientObject(ctx, "TestGateNodeObject", objID)
+		err = gateCluster.DeleteObject(ctx, "TestGateNodeObject", objID)
 		if err != nil {
 			t.Fatalf("DeleteObject via gate failed for %s: %v", objID, err)
 		}
@@ -524,7 +524,7 @@ func TestGateNodeIntegration(t *testing.T) {
 
 		// Delete all objects
 		for _, objID := range objectIDs {
-			err := gateCluster.DeleteClientObject(ctx, "TestGateNodeObject", objID)
+			err := gateCluster.DeleteObject(ctx, "TestGateNodeObject", objID)
 			if err != nil {
 				t.Fatalf("DeleteObject via gate failed for %s: %v", objID, err)
 			}
@@ -576,7 +576,7 @@ func TestGateNodeIntegration(t *testing.T) {
 		t.Logf("Object %s has state: callCount=%d", objID, incResult)
 
 		// Delete the object
-		err = gateCluster.DeleteClientObject(ctx, "TestGateNodeObject", objID)
+		err = gateCluster.DeleteObject(ctx, "TestGateNodeObject", objID)
 		if err != nil {
 			t.Fatalf("DeleteObject via gate failed for %s: %v", objID, err)
 		}

--- a/docs/ASYNC_OPERATIONS.md
+++ b/docs/ASYNC_OPERATIONS.md
@@ -74,7 +74,7 @@ func (obj *MyObject) CreateChild(ctx context.Context, req *CreateChildRequest) (
 ```go
 func (obj *MyObject) DeleteChild(ctx context.Context, req *DeleteChildRequest) (*Response, error) {
     // This returns immediately - object deletion happens asynchronously
-    err := goverseapi.DeleteObject(ctx, req.ChildId)
+    err := goverseapi.DeleteObject(ctx, "ChildObject", req.ChildId)
     if err != nil {
         // Only errors in node routing are returned
         return nil, err

--- a/docs/GOVERSEAPI.md
+++ b/docs/GOVERSEAPI.md
@@ -217,13 +217,14 @@ id, err := goverseapi.CreateObject(ctx, "Counter", objID)
 ### DeleteObject
 
 ```go
-func DeleteObject(ctx context.Context, objID string) error
+func DeleteObject(ctx context.Context, objType, objID string) error
 ```
 
-Deletes an object from the cluster.
+Deletes an object from the cluster. The receiving node verifies the
+supplied type matches the object's real type and rejects mismatches.
 
 ```go
-err := goverseapi.DeleteObject(ctx, "Counter-my-counter")
+err := goverseapi.DeleteObject(ctx, "Counter", "Counter-my-counter")
 ```
 
 ---

--- a/docs/design/V0_2_TRUST_BOUNDARY.md
+++ b/docs/design/V0_2_TRUST_BOUNDARY.md
@@ -223,51 +223,72 @@ and the least surprising for callers.
 // gate/proto/gate.proto
 message DeleteObjectRequest {
     string id = 1;
-    // type is required for v0.2's gate-side access check. Empty
-    // type is accepted for backwards compatibility but logs a
-    // warning and skips the check (v0.1 behaviour). v0.3 will
-    // reject empty type.
+    // type is required so the gate can run an advisory
+    // CheckClientDelete early-reject. Empty type is rejected.
     string type = 2;
 }
 ```
 
-HTTP route: `POST /api/v1/objects/delete/{type}/{id}` (new). The old
-route `POST /api/v1/objects/delete/{id}` keeps working as the legacy
-v0.1 path with the same warn-and-skip semantics.
+HTTP route: `POST /api/v1/objects/delete/{type}/{id}`. There is no
+legacy untyped fallback — the single-segment path is rejected with
+400.
+
+The gate's check is **advisory** because the client-supplied type is
+untrusted: a malicious caller can claim an allowed type for an id
+that resolves to a protected object. The authoritative authorization
+runs at the receiving node (`node.DeleteClientObject`) against the
+object's *real* type, fetched from the node's registry. Plumbing:
+
+```proto
+// proto/goverse.proto (inter-node service)
+message DeleteObjectRequest {
+    string id = 1;
+    bool from_client = 2; // gate-originated → node uses CheckClientDelete
+}
+```
 
 ### 5.3 Implementation
 
-- Regenerate `gate/proto/gate.pb.go`.
-- `gate/gateserver/gateserver.go:DeleteObject`: read `req.Type`,
-  call `CheckClientDelete(req.Type, req.Id)` if validator configured
-  and type is non-empty; warn-and-skip if empty.
-- `gate/gateserver/http_handler.go:handleDeleteObject`: register
-  the new `/api/v1/objects/delete/{type}/{id}` route alongside the
-  legacy one. Same access check.
+- Regenerate `gate/proto/gate.pb.go` and `proto/goverse.pb.go`.
+- `gate/gateserver/gateserver.go:DeleteObject`: reject empty
+  `req.Type` with `InvalidArgument`; otherwise run the advisory
+  `CheckClientDelete(req.Type, req.Id)` and forward via
+  `cluster.DeleteClientObject`.
+- `gate/gateserver/http_handler.go:handleDeleteObject`: require the
+  two-segment path; reject `/api/v1/objects/delete/{id}` with 400.
+  Same advisory check.
+- `cluster.DeleteClientObject(ctx, id)` is the gate-originated
+  counterpart to `cluster.DeleteObject(ctx, id)`. It tags the
+  inter-node RPC with `from_client=true`.
+- `node.DeleteClientObject(ctx, id)` is the gate-originated
+  counterpart to `node.DeleteObject(ctx, id)`. It runs
+  `CheckClientDelete` on `obj.Type()` from the registry.
+- `server.go:DeleteObject` dispatches between the two based on
+  `req.FromClient`.
 - `client/goverseclient/client.go` + Python client: `DeleteObject`
-  takes `type` (positional) — breaking-extending. v0.2 minor bump
-  is the right place for it.
+  takes `type` (positional). v0.2 minor bump.
 
 ### 5.4 Migration
 
-- Existing gRPC clients that send empty type: warn-once-per-deploy
-  log line so operators notice. Calls still succeed in v0.2.
-- Existing HTTP clients on `POST /api/v1/objects/delete/{id}`:
-  same — call succeeds, warn logged.
-- New code uses the typed path. v0.3 deprecates the legacy path.
+The wire format adds the `type` field on the gate-side
+`DeleteObjectRequest` and a `from_client` flag on the inter-node
+`DeleteObjectRequest`. v0.1 callers that omit type get rejected at
+the gate (gRPC `InvalidArgument`, HTTP 400) — they need to pass
+type when they upgrade.
 
 ### 5.5 Test strategy
 
-- New `TestHandleDeleteObject_LifecycleRejected` mirroring
-  `TestHandleCreateObject_LifecycleRejected` from PR #549.
-- gRPC variant in `gateserver_test.go`.
-- Backwards-compat test: empty type passes through with warn.
-
-### 5.6 Open decisions
-
-- **`[DECIDE]`** Should empty type *fail* in v0.2 or just warn? Default:
-  warn. Failing is right semantically, but breaks the upgrade path.
-  v0.3 fails.
+- `TestHandleDeleteObject_LifecycleRejected` — typed HTTP path with
+  INTERNAL DELETE rule returns 403.
+- `TestHandleDeleteObject_RejectsUntypedPath` — single-segment path
+  returns 400.
+- `TestDeleteObject_gRPC_RejectsEmptyType` — empty `req.Type` returns
+  `InvalidArgument`.
+- `TestDeleteObject_gRPC_LifecycleRejected` — gRPC handler returns
+  `PermissionDenied` for a denied lifecycle rule.
+- `TestNode_DeleteClientObject_UsesRealTypeForCheck` — node-level
+  pin that the from-client path authorizes against the object's
+  registry-resolved type, not anything the gate received.
 
 ---
 

--- a/docs/design/V0_2_TRUST_BOUNDARY.md
+++ b/docs/design/V0_2_TRUST_BOUNDARY.md
@@ -233,23 +233,30 @@ HTTP route: `POST /api/v1/objects/delete/{type}/{id}`. There is no
 legacy untyped fallback — the single-segment path is rejected with
 400.
 
-Authorization is split across the gate and the receiving node:
+Authorization mirrors `CreateObject`: the gate runs the client-side
+check, the node runs the node-side check. Layered:
 
-- **Gate** runs `CheckClientDelete` on the client-supplied type. This
-  is the authoritative authorization decision — a request the gate
-  rejects never reaches the node.
-- **Node** verifies the client-claimed type matches the object's
-  real type fetched from its registry, and rejects mismatches. This
-  closes the spoof gap where a client could claim an allowed type
-  for an id that resolves to a protected object.
+- **Gate** runs `CheckClientDelete` on the client-supplied type
+  before forwarding. A request the gate rejects never reaches the
+  node.
+- **Node** verifies the supplied type matches the object's real
+  type from its registry, rejecting mismatches (closes the spoof
+  gap). On match it then runs `CheckNodeDelete` on the (now
+  trustworthy) type — symmetric with `node.createObject` running
+  `CheckNodeCreate`.
 
-Together: gate authorizes, node verifies identity. Plumbing:
+Note: `EXTERNAL DELETE` rules have the same known limitation as
+`EXTERNAL CREATE` — client-originated calls pass the gate's
+`CheckClient*` but get re-checked against `CheckNode*` at the
+destination, which fails for `EXTERNAL`. Future work can plumb a
+caller-origin signal symmetrically for both create and delete; out
+of scope for v0.2.
 
 ```proto
 // proto/goverse.proto (inter-node service)
 message DeleteObjectRequest {
     string id = 1;
-    string type = 2; // claimed type for spoof verification at node
+    string type = 2; // forwarded to the node for spoof verification
 }
 ```
 
@@ -259,22 +266,17 @@ message DeleteObjectRequest {
 - `gate/gateserver/gateserver.go:DeleteObject`: reject empty
   `req.Type` with `InvalidArgument`; otherwise run
   `CheckClientDelete(req.Type, req.Id)` and forward via
-  `cluster.DeleteClientObject`.
+  `cluster.DeleteObject`.
 - `gate/gateserver/http_handler.go:handleDeleteObject`: require the
   two-segment path; reject `/api/v1/objects/delete/{id}` with 400.
   Same authorization check.
-- `cluster.DeleteObject(ctx, type, id)` is the entry point for
-  node-internal callers. It runs `CheckNodeDelete` against the
-  supplied type via the local node's validator before routing.
-- `cluster.DeleteClientObject(ctx, type, id)` is the gate-originated
-  counterpart. The gate has already authorized via
-  `CheckClientDelete`, so this layer skips the lifecycle check and
-  just routes.
-- `node.DeleteObject(ctx, type, id)` is the single node-side entry
-  point. It verifies `obj.Type() == type` and rejects mismatches.
-  No lifecycle check at this layer — authorization belongs to the
-  caller (gate or `cluster.DeleteObject`).
-- `server.go:DeleteObject` is one line: forward `req.GetType()` and
+- `cluster.DeleteObject(ctx, type, id)` is the only cluster-side
+  delete entry point. It just routes; lifecycle authorization lives
+  at the gate (for client deletes) or at the node (for both).
+- `node.DeleteObject(ctx, type, id)` verifies `obj.Type() == type`,
+  rejects mismatches, then runs `CheckNodeDelete` on the matched
+  type — mirroring `createObject`'s `CheckNodeCreate`.
+- `server.go:DeleteObject` forwards `req.GetType()` and
   `req.GetId()` straight to `node.DeleteObject`.
 - `goverseapi.DeleteObject(ctx, type, id)` takes `type` as a new
   positional argument; calls `cluster.DeleteObject`.

--- a/docs/design/V0_2_TRUST_BOUNDARY.md
+++ b/docs/design/V0_2_TRUST_BOUNDARY.md
@@ -233,17 +233,23 @@ HTTP route: `POST /api/v1/objects/delete/{type}/{id}`. There is no
 legacy untyped fallback — the single-segment path is rejected with
 400.
 
-The gate's check is **advisory** because the client-supplied type is
-untrusted: a malicious caller can claim an allowed type for an id
-that resolves to a protected object. The authoritative authorization
-runs at the receiving node (`node.DeleteClientObject`) against the
-object's *real* type, fetched from the node's registry. Plumbing:
+Authorization is split across the gate and the receiving node:
+
+- **Gate** runs `CheckClientDelete` on the client-supplied type. This
+  is the authoritative authorization decision — a request the gate
+  rejects never reaches the node.
+- **Node** verifies the client-claimed type matches the object's
+  real type fetched from its registry, and rejects mismatches. This
+  closes the spoof gap where a client could claim an allowed type
+  for an id that resolves to a protected object.
+
+Together: gate authorizes, node verifies identity. Plumbing:
 
 ```proto
 // proto/goverse.proto (inter-node service)
 message DeleteObjectRequest {
     string id = 1;
-    bool from_client = 2; // gate-originated → node uses CheckClientDelete
+    string type = 2; // claimed type for spoof verification at node
 }
 ```
 
@@ -251,28 +257,29 @@ message DeleteObjectRequest {
 
 - Regenerate `gate/proto/gate.pb.go` and `proto/goverse.pb.go`.
 - `gate/gateserver/gateserver.go:DeleteObject`: reject empty
-  `req.Type` with `InvalidArgument`; otherwise run the advisory
+  `req.Type` with `InvalidArgument`; otherwise run
   `CheckClientDelete(req.Type, req.Id)` and forward via
   `cluster.DeleteClientObject`.
 - `gate/gateserver/http_handler.go:handleDeleteObject`: require the
   two-segment path; reject `/api/v1/objects/delete/{id}` with 400.
-  Same advisory check.
-- `cluster.DeleteClientObject(ctx, id)` is the gate-originated
-  counterpart to `cluster.DeleteObject(ctx, id)`. It tags the
-  inter-node RPC with `from_client=true`.
-- `node.DeleteClientObject(ctx, id)` is the gate-originated
-  counterpart to `node.DeleteObject(ctx, id)`. It runs
-  `CheckClientDelete` on `obj.Type()` from the registry.
+  Same authorization check.
+- `cluster.DeleteClientObject(ctx, claimedType, id)` is the
+  gate-originated counterpart to `cluster.DeleteObject(ctx, id)`. It
+  threads the claimed type through the inter-node RPC.
+- `node.DeleteClientObject(ctx, claimedType, id)` is the
+  gate-originated counterpart to `node.DeleteObject(ctx, id)`. It
+  verifies `obj.Type() == claimedType` and rejects mismatches; on
+  match it skips `CheckNodeDelete` because the gate already
+  authorized.
 - `server.go:DeleteObject` dispatches between the two based on
-  `req.FromClient`.
+  whether `req.Type` is empty.
 - `client/goverseclient/client.go` + Python client: `DeleteObject`
   takes `type` (positional). v0.2 minor bump.
 
 ### 5.4 Migration
 
-The wire format adds the `type` field on the gate-side
-`DeleteObjectRequest` and a `from_client` flag on the inter-node
-`DeleteObjectRequest`. v0.1 callers that omit type get rejected at
+Both `DeleteObjectRequest` messages (gate-facing and inter-node)
+gain a `type` field. v0.1 callers that omit type get rejected at
 the gate (gRPC `InvalidArgument`, HTTP 400) — they need to pass
 type when they upgrade.
 
@@ -286,9 +293,11 @@ type when they upgrade.
   `InvalidArgument`.
 - `TestDeleteObject_gRPC_LifecycleRejected` — gRPC handler returns
   `PermissionDenied` for a denied lifecycle rule.
-- `TestNode_DeleteClientObject_UsesRealTypeForCheck` — node-level
-  pin that the from-client path authorizes against the object's
-  registry-resolved type, not anything the gate received.
+- `TestNode_DeleteClientObject_RejectsTypeSpoof` — node-level pin
+  that a claimed type which doesn't match the registry type is
+  rejected, even if the gate would have authorized it.
+- `TestNode_DeleteClientObject_RequiresClaimedType` — pins that
+  the gate-originated path always carries a claimed type.
 
 ---
 

--- a/docs/design/V0_2_TRUST_BOUNDARY.md
+++ b/docs/design/V0_2_TRUST_BOUNDARY.md
@@ -263,25 +263,34 @@ message DeleteObjectRequest {
 - `gate/gateserver/http_handler.go:handleDeleteObject`: require the
   two-segment path; reject `/api/v1/objects/delete/{id}` with 400.
   Same authorization check.
-- `cluster.DeleteClientObject(ctx, claimedType, id)` is the
-  gate-originated counterpart to `cluster.DeleteObject(ctx, id)`. It
-  threads the claimed type through the inter-node RPC.
-- `node.DeleteClientObject(ctx, claimedType, id)` is the
-  gate-originated counterpart to `node.DeleteObject(ctx, id)`. It
-  verifies `obj.Type() == claimedType` and rejects mismatches; on
-  match it skips `CheckNodeDelete` because the gate already
-  authorized.
-- `server.go:DeleteObject` dispatches between the two based on
-  whether `req.Type` is empty.
+- `cluster.DeleteObject(ctx, type, id)` is the entry point for
+  node-internal callers. It runs `CheckNodeDelete` against the
+  supplied type via the local node's validator before routing.
+- `cluster.DeleteClientObject(ctx, type, id)` is the gate-originated
+  counterpart. The gate has already authorized via
+  `CheckClientDelete`, so this layer skips the lifecycle check and
+  just routes.
+- `node.DeleteObject(ctx, type, id)` is the single node-side entry
+  point. It verifies `obj.Type() == type` and rejects mismatches.
+  No lifecycle check at this layer — authorization belongs to the
+  caller (gate or `cluster.DeleteObject`).
+- `server.go:DeleteObject` is one line: forward `req.GetType()` and
+  `req.GetId()` straight to `node.DeleteObject`.
+- `goverseapi.DeleteObject(ctx, type, id)` takes `type` as a new
+  positional argument; calls `cluster.DeleteObject`.
 - `client/goverseclient/client.go` + Python client: `DeleteObject`
   takes `type` (positional). v0.2 minor bump.
 
 ### 5.4 Migration
 
 Both `DeleteObjectRequest` messages (gate-facing and inter-node)
-gain a `type` field. v0.1 callers that omit type get rejected at
-the gate (gRPC `InvalidArgument`, HTTP 400) — they need to pass
-type when they upgrade.
+gain a `type` field. The gate-facing `goverseapi.DeleteObject`,
+`Client.DeleteObject` (Go), and `Client.delete_object` (Python)
+each gain a `type` argument as well.
+
+v0.1 callers that omit type get rejected at the gate (gRPC
+`InvalidArgument`, HTTP 400) — they need to pass type when they
+upgrade.
 
 ### 5.5 Test strategy
 
@@ -293,11 +302,12 @@ type when they upgrade.
   `InvalidArgument`.
 - `TestDeleteObject_gRPC_LifecycleRejected` — gRPC handler returns
   `PermissionDenied` for a denied lifecycle rule.
-- `TestNode_DeleteClientObject_RejectsTypeSpoof` — node-level pin
-  that a claimed type which doesn't match the registry type is
-  rejected, even if the gate would have authorized it.
-- `TestNode_DeleteClientObject_RequiresClaimedType` — pins that
-  the gate-originated path always carries a claimed type.
+- `TestNode_DeleteObject_RejectsTypeSpoof` — node-level pin that a
+  claimed type which doesn't match the registry type is rejected,
+  even if the gate would have authorized it.
+- `TestNode_DeleteObject_RequiresType` — pins that node-side delete
+  always requires a non-empty type (programming-contract error to
+  omit it).
 
 ---
 

--- a/gate/gateserver/delete_access_test.go
+++ b/gate/gateserver/delete_access_test.go
@@ -56,44 +56,58 @@ func TestHandleDeleteObject_LifecycleRejected(t *testing.T) {
 	}
 }
 
-// TestHandleDeleteObject_LegacyUntypedSkipsCheck confirms that the
-// legacy POST /api/v1/objects/delete/{id} path keeps working in v0.2:
-// the lifecycle check is skipped (with a warning) instead of
-// rejecting, so v0.1 clients keep deleting until they upgrade to the
-// typed route. v0.3 will tighten this.
-//
-// Without a real cluster wired in, the call panics inside
-// s.cluster.DeleteObject — which is exactly the proof we need that
-// the untyped path bypassed the access check and got through to the
-// cluster path. recover() catches the panic so the test asserts the
-// validator's behaviour, not the cluster's.
-func TestHandleDeleteObject_LegacyUntypedSkipsCheck(t *testing.T) {
-	rules := []config.LifecycleRule{
-		// Even a default-deny rule must NOT block the legacy untyped
-		// path — empty type warns and skips, by design.
-		{Type: "Restricted", Lifecycle: "DELETE", Access: "REJECT"},
-	}
-	validator, err := config.NewLifecycleValidator(rules)
-	if err != nil {
-		t.Fatalf("NewLifecycleValidator: %v", err)
-	}
-
+// TestHandleDeleteObject_RejectsUntypedPath confirms the HTTP delete
+// route requires the typed form /api/v1/objects/delete/{type}/{id}.
+// The single-segment path is rejected with 400 — type is required so
+// the gate has the input it needs for its advisory check.
+func TestHandleDeleteObject_RejectsUntypedPath(t *testing.T) {
 	s := &GateServer{
-		logger:             logger.NewLogger("test-gate"),
-		lifecycleValidator: validator,
+		logger: logger.NewLogger("test-gate"),
 	}
 
 	req := httptest.NewRequest(http.MethodPost,
 		"/api/v1/objects/delete/some-id", nil)
 	w := httptest.NewRecorder()
 
-	defer func() {
-		_ = recover()
-		if w.Code == http.StatusForbidden {
-			t.Fatalf("legacy untyped delete unexpectedly produced 403; should warn-and-skip the lifecycle check")
-		}
-	}()
 	s.handleDeleteObject(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d; want 400 Bad Request", w.Code)
+	}
+	respBody, _ := io.ReadAll(w.Body)
+	var errResp HTTPErrorResponse
+	if err := json.Unmarshal(respBody, &errResp); err != nil {
+		t.Fatalf("decode error response: %v\nbody=%s", err, string(respBody))
+	}
+	if errResp.Code != "INVALID_PATH" {
+		t.Fatalf("error code = %q; want INVALID_PATH. body=%s", errResp.Code, string(respBody))
+	}
+}
+
+// TestDeleteObject_gRPC_RejectsEmptyType pins that the gRPC handler
+// rejects requests without a type field — counterpart to the HTTP
+// route's INVALID_PATH rejection. The receiving node still does the
+// authoritative check on real type; the gate just refuses to forward
+// without the second arg its advisory check needs.
+func TestDeleteObject_gRPC_RejectsEmptyType(t *testing.T) {
+	s := &GateServer{
+		config: &GateServerConfig{DefaultDeleteTimeout: 5 * time.Second},
+		logger: logger.NewLogger("test-gate"),
+	}
+
+	_, err := s.DeleteObject(context.Background(), &gate_pb.DeleteObjectRequest{
+		Id: "some-id",
+	})
+	if err == nil {
+		t.Fatalf("DeleteObject succeeded with empty type; want InvalidArgument")
+	}
+	st, ok := status.FromError(err)
+	if !ok {
+		t.Fatalf("error is not a gRPC status: %v", err)
+	}
+	if st.Code() != codes.InvalidArgument {
+		t.Fatalf("status code = %v; want InvalidArgument", st.Code())
+	}
 }
 
 // TestDeleteObject_gRPC_LifecycleRejected pins the gate's gRPC

--- a/gate/gateserver/delete_access_test.go
+++ b/gate/gateserver/delete_access_test.go
@@ -1,0 +1,130 @@
+package gateserver
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/xiaonanln/goverse/config"
+	gate_pb "github.com/xiaonanln/goverse/gate/proto"
+	"github.com/xiaonanln/goverse/util/logger"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// TestHandleDeleteObject_LifecycleRejected pins the gate's HTTP
+// handleDeleteObject lifecycle check on the typed
+// /api/v1/objects/delete/{type}/{id} route. Mirrors
+// TestHandleCreateObject_LifecycleRejected; without this check, an
+// INTERNAL/REJECT lifecycle rule would only be enforced for
+// streaming-gRPC clients and a browser POST would slip past gate-side
+// validation.
+func TestHandleDeleteObject_LifecycleRejected(t *testing.T) {
+	rules := []config.LifecycleRule{
+		{Type: "Restricted", Lifecycle: "DELETE", Access: "INTERNAL"},
+	}
+	validator, err := config.NewLifecycleValidator(rules)
+	if err != nil {
+		t.Fatalf("NewLifecycleValidator: %v", err)
+	}
+
+	s := &GateServer{
+		logger:             logger.NewLogger("test-gate"),
+		lifecycleValidator: validator,
+	}
+
+	req := httptest.NewRequest(http.MethodPost,
+		"/api/v1/objects/delete/Restricted/some-id", nil)
+	w := httptest.NewRecorder()
+
+	s.handleDeleteObject(w, req)
+
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("status = %d; want 403 Forbidden", w.Code)
+	}
+	respBody, _ := io.ReadAll(w.Body)
+	var errResp HTTPErrorResponse
+	if err := json.Unmarshal(respBody, &errResp); err != nil {
+		t.Fatalf("decode error response: %v\nbody=%s", err, string(respBody))
+	}
+	if errResp.Code != "ACCESS_DENIED" {
+		t.Fatalf("error code = %q; want ACCESS_DENIED. body=%s", errResp.Code, string(respBody))
+	}
+}
+
+// TestHandleDeleteObject_LegacyUntypedSkipsCheck confirms that the
+// legacy POST /api/v1/objects/delete/{id} path keeps working in v0.2:
+// the lifecycle check is skipped (with a warning) instead of
+// rejecting, so v0.1 clients keep deleting until they upgrade to the
+// typed route. v0.3 will tighten this.
+//
+// Without a real cluster wired in, the call panics inside
+// s.cluster.DeleteObject — which is exactly the proof we need that
+// the untyped path bypassed the access check and got through to the
+// cluster path. recover() catches the panic so the test asserts the
+// validator's behaviour, not the cluster's.
+func TestHandleDeleteObject_LegacyUntypedSkipsCheck(t *testing.T) {
+	rules := []config.LifecycleRule{
+		// Even a default-deny rule must NOT block the legacy untyped
+		// path — empty type warns and skips, by design.
+		{Type: "Restricted", Lifecycle: "DELETE", Access: "REJECT"},
+	}
+	validator, err := config.NewLifecycleValidator(rules)
+	if err != nil {
+		t.Fatalf("NewLifecycleValidator: %v", err)
+	}
+
+	s := &GateServer{
+		logger:             logger.NewLogger("test-gate"),
+		lifecycleValidator: validator,
+	}
+
+	req := httptest.NewRequest(http.MethodPost,
+		"/api/v1/objects/delete/some-id", nil)
+	w := httptest.NewRecorder()
+
+	defer func() {
+		_ = recover()
+		if w.Code == http.StatusForbidden {
+			t.Fatalf("legacy untyped delete unexpectedly produced 403; should warn-and-skip the lifecycle check")
+		}
+	}()
+	s.handleDeleteObject(w, req)
+}
+
+// TestDeleteObject_gRPC_LifecycleRejected pins the gate's gRPC
+// DeleteObject lifecycle check. Counterpart to the HTTP test above.
+func TestDeleteObject_gRPC_LifecycleRejected(t *testing.T) {
+	rules := []config.LifecycleRule{
+		{Type: "Restricted", Lifecycle: "DELETE", Access: "INTERNAL"},
+	}
+	validator, err := config.NewLifecycleValidator(rules)
+	if err != nil {
+		t.Fatalf("NewLifecycleValidator: %v", err)
+	}
+
+	s := &GateServer{
+		config:             &GateServerConfig{DefaultDeleteTimeout: 5 * time.Second},
+		logger:             logger.NewLogger("test-gate"),
+		lifecycleValidator: validator,
+	}
+
+	_, err = s.DeleteObject(context.Background(), &gate_pb.DeleteObjectRequest{
+		Type: "Restricted",
+		Id:   "some-id",
+	})
+	if err == nil {
+		t.Fatalf("DeleteObject succeeded; want PermissionDenied")
+	}
+	st, ok := status.FromError(err)
+	if !ok {
+		t.Fatalf("error is not a gRPC status: %v", err)
+	}
+	if st.Code() != codes.PermissionDenied {
+		t.Fatalf("status code = %v; want PermissionDenied", st.Code())
+	}
+}

--- a/gate/gateserver/gate_http_integration_test.go
+++ b/gate/gateserver/gate_http_integration_test.go
@@ -286,8 +286,8 @@ func TestGateHTTPIntegration(t *testing.T) {
 	})
 
 	t.Run("DeleteObjectViaHTTP", func(t *testing.T) {
-		// POST /api/v1/objects/delete/{id}
-		url := fmt.Sprintf("%s/api/v1/objects/delete/%s", httpBaseURL, objID)
+		// POST /api/v1/objects/delete/{type}/{id}
+		url := fmt.Sprintf("%s/api/v1/objects/delete/%s/%s", httpBaseURL, objType, objID)
 		req, err := http.NewRequest(http.MethodPost, url, nil)
 		if err != nil {
 			t.Fatalf("Failed to create HTTP request: %v", err)
@@ -541,8 +541,8 @@ func TestGateHTTPIntegrationWithCurl(t *testing.T) {
 	})
 
 	t.Run("DeleteObjectViaCurl", func(t *testing.T) {
-		// POST /api/v1/objects/delete/{id}
-		url := fmt.Sprintf("%s/api/v1/objects/delete/%s", httpBaseURL, objID)
+		// POST /api/v1/objects/delete/{type}/{id}
+		url := fmt.Sprintf("%s/api/v1/objects/delete/%s/%s", httpBaseURL, objType, objID)
 
 		statusCode, bodyBytes := curlPostHelper(t, url, nil)
 

--- a/gate/gateserver/gate_node_integration_test.go
+++ b/gate/gateserver/gate_node_integration_test.go
@@ -268,7 +268,8 @@ func TestGateNodeIntegrationSimple(t *testing.T) {
 
 		// Delete first object via the gate
 		deleteReq1 := &gate_pb.DeleteObjectRequest{
-			Id: objID1,
+			Type: "TestGateNodeObject",
+			Id:   objID1,
 		}
 		_, err = gateClient.DeleteObject(ctx, deleteReq1)
 		if err != nil {
@@ -277,7 +278,8 @@ func TestGateNodeIntegrationSimple(t *testing.T) {
 
 		// Delete second object via the gate
 		deleteReq2 := &gate_pb.DeleteObjectRequest{
-			Id: objID2,
+			Type: "TestGateNodeObject",
+			Id:   objID2,
 		}
 		_, err = gateClient.DeleteObject(ctx, deleteReq2)
 		if err != nil {
@@ -643,7 +645,8 @@ func TestGateNodeIntegrationMulti(t *testing.T) {
 
 		// Delete objects via gate1
 		deleteReq1 := &gate_pb.DeleteObjectRequest{
-			Id: objID1,
+			Type: "TestGateNodeObject",
+			Id:   objID1,
 		}
 		_, err = gateClient1.DeleteObject(ctx, deleteReq1)
 		if err != nil {
@@ -651,7 +654,8 @@ func TestGateNodeIntegrationMulti(t *testing.T) {
 		}
 
 		deleteReq3 := &gate_pb.DeleteObjectRequest{
-			Id: objID3,
+			Type: "TestGateNodeObject",
+			Id:   objID3,
 		}
 		_, err = gateClient1.DeleteObject(ctx, deleteReq3)
 		if err != nil {
@@ -660,7 +664,8 @@ func TestGateNodeIntegrationMulti(t *testing.T) {
 
 		// Delete objects via gate2
 		deleteReq2 := &gate_pb.DeleteObjectRequest{
-			Id: objID2,
+			Type: "TestGateNodeObject",
+			Id:   objID2,
 		}
 		_, err = gateClient2.DeleteObject(ctx, deleteReq2)
 		if err != nil {
@@ -668,7 +673,8 @@ func TestGateNodeIntegrationMulti(t *testing.T) {
 		}
 
 		deleteReq4 := &gate_pb.DeleteObjectRequest{
-			Id: objID4,
+			Type: "TestGateNodeObject",
+			Id:   objID4,
 		}
 		_, err = gateClient2.DeleteObject(ctx, deleteReq4)
 		if err != nil {

--- a/gate/gateserver/gateserver.go
+++ b/gate/gateserver/gateserver.go
@@ -364,6 +364,18 @@ func (s *GateServer) DeleteObject(ctx context.Context, req *gate_pb.DeleteObject
 	ctx, cancel := callcontext.WithDefaultTimeout(ctx, s.config.DefaultDeleteTimeout)
 	defer cancel()
 
+	// Check lifecycle rules for DELETE if a lifecycle validator is
+	// configured. Empty type is accepted for backwards compatibility
+	// with v0.1 clients but skips the check (v0.3 will reject).
+	if s.lifecycleValidator != nil {
+		if req.Type == "" {
+			s.logger.Warnf("DeleteObject called without type for id=%s; skipping lifecycle check (v0.1 compat)", req.Id)
+		} else if err := s.lifecycleValidator.CheckClientDelete(req.Type, req.Id); err != nil {
+			s.logger.Warnf("Delete denied for client: type=%s, id=%s: %v", req.Type, req.Id, err)
+			return nil, status.Errorf(codes.PermissionDenied, "%v", err)
+		}
+	}
+
 	// Call the cluster to delete the object
 	err := s.cluster.DeleteObject(ctx, req.Id)
 	if err != nil {

--- a/gate/gateserver/gateserver.go
+++ b/gate/gateserver/gateserver.go
@@ -364,20 +364,26 @@ func (s *GateServer) DeleteObject(ctx context.Context, req *gate_pb.DeleteObject
 	ctx, cancel := callcontext.WithDefaultTimeout(ctx, s.config.DefaultDeleteTimeout)
 	defer cancel()
 
-	// Check lifecycle rules for DELETE if a lifecycle validator is
-	// configured. Empty type is accepted for backwards compatibility
-	// with v0.1 clients but skips the check (v0.3 will reject).
+	// Advisory early-reject using the client-supplied type. The gate
+	// can't trust this value (a malicious client can claim an allowed
+	// type and ask for an id that resolves to a protected object), so
+	// the authoritative authorization happens at the receiving node
+	// via cluster.DeleteClientObject → node.DeleteClientObject, where
+	// the lifecycle check runs against the object's real type.
+	// Empty type is accepted for backwards compatibility with v0.1
+	// clients (warn-and-skip; v0.3 will reject).
 	if s.lifecycleValidator != nil {
 		if req.Type == "" {
-			s.logger.Warnf("DeleteObject called without type for id=%s; skipping lifecycle check (v0.1 compat)", req.Id)
+			s.logger.Warnf("DeleteObject called without type for id=%s; skipping advisory lifecycle check (v0.1 compat)", req.Id)
 		} else if err := s.lifecycleValidator.CheckClientDelete(req.Type, req.Id); err != nil {
-			s.logger.Warnf("Delete denied for client: type=%s, id=%s: %v", req.Type, req.Id, err)
+			s.logger.Warnf("Delete denied for client (advisory): type=%s, id=%s: %v", req.Type, req.Id, err)
 			return nil, status.Errorf(codes.PermissionDenied, "%v", err)
 		}
 	}
 
-	// Call the cluster to delete the object
-	err := s.cluster.DeleteObject(ctx, req.Id)
+	// Forward as a client-originated delete so the receiving node uses
+	// CheckClientDelete with the real object type.
+	err := s.cluster.DeleteClientObject(ctx, req.Id)
 	if err != nil {
 		return nil, err
 	}

--- a/gate/gateserver/gateserver.go
+++ b/gate/gateserver/gateserver.go
@@ -383,7 +383,7 @@ func (s *GateServer) DeleteObject(ctx context.Context, req *gate_pb.DeleteObject
 
 	// Forward the claimed type so the node can verify it matches
 	// the object's real type before deleting.
-	err := s.cluster.DeleteClientObject(ctx, req.Type, req.Id)
+	err := s.cluster.DeleteObject(ctx, req.Type, req.Id)
 	if err != nil {
 		return nil, err
 	}

--- a/gate/gateserver/gateserver.go
+++ b/gate/gateserver/gateserver.go
@@ -364,26 +364,26 @@ func (s *GateServer) DeleteObject(ctx context.Context, req *gate_pb.DeleteObject
 	ctx, cancel := callcontext.WithDefaultTimeout(ctx, s.config.DefaultDeleteTimeout)
 	defer cancel()
 
-	// Type is required: the gate runs an advisory early-reject via
-	// CheckClientDelete on it. The client-supplied value is untrusted
-	// (a malicious caller can claim an allowed type for an id that
-	// resolves to a protected object), so the authoritative
-	// authorization happens at the receiving node via
-	// cluster.DeleteClientObject → node.DeleteClientObject, where the
-	// lifecycle check runs against the object's real type.
+	// Type is required so the gate can authorize the delete via
+	// CheckClientDelete on the client-supplied type. That value is
+	// not trusted on its own — a malicious caller can claim an
+	// allowed type for an id that resolves to a protected object —
+	// so the claim is forwarded to the node, which verifies it
+	// against the object's real type and rejects mismatches.
+	// Together: gate authorizes, node verifies identity.
 	if req.Type == "" {
 		return nil, status.Errorf(codes.InvalidArgument, "DeleteObject requires type")
 	}
 	if s.lifecycleValidator != nil {
 		if err := s.lifecycleValidator.CheckClientDelete(req.Type, req.Id); err != nil {
-			s.logger.Warnf("Delete denied for client (advisory): type=%s, id=%s: %v", req.Type, req.Id, err)
+			s.logger.Warnf("Delete denied for client: type=%s, id=%s: %v", req.Type, req.Id, err)
 			return nil, status.Errorf(codes.PermissionDenied, "%v", err)
 		}
 	}
 
-	// Forward as a client-originated delete so the receiving node uses
-	// CheckClientDelete with the real object type.
-	err := s.cluster.DeleteClientObject(ctx, req.Id)
+	// Forward the claimed type so the node can verify it matches
+	// the object's real type before deleting.
+	err := s.cluster.DeleteClientObject(ctx, req.Type, req.Id)
 	if err != nil {
 		return nil, err
 	}

--- a/gate/gateserver/gateserver.go
+++ b/gate/gateserver/gateserver.go
@@ -364,18 +364,18 @@ func (s *GateServer) DeleteObject(ctx context.Context, req *gate_pb.DeleteObject
 	ctx, cancel := callcontext.WithDefaultTimeout(ctx, s.config.DefaultDeleteTimeout)
 	defer cancel()
 
-	// Advisory early-reject using the client-supplied type. The gate
-	// can't trust this value (a malicious client can claim an allowed
-	// type and ask for an id that resolves to a protected object), so
-	// the authoritative authorization happens at the receiving node
-	// via cluster.DeleteClientObject → node.DeleteClientObject, where
-	// the lifecycle check runs against the object's real type.
-	// Empty type is accepted for backwards compatibility with v0.1
-	// clients (warn-and-skip; v0.3 will reject).
+	// Type is required: the gate runs an advisory early-reject via
+	// CheckClientDelete on it. The client-supplied value is untrusted
+	// (a malicious caller can claim an allowed type for an id that
+	// resolves to a protected object), so the authoritative
+	// authorization happens at the receiving node via
+	// cluster.DeleteClientObject → node.DeleteClientObject, where the
+	// lifecycle check runs against the object's real type.
+	if req.Type == "" {
+		return nil, status.Errorf(codes.InvalidArgument, "DeleteObject requires type")
+	}
 	if s.lifecycleValidator != nil {
-		if req.Type == "" {
-			s.logger.Warnf("DeleteObject called without type for id=%s; skipping advisory lifecycle check (v0.1 compat)", req.Id)
-		} else if err := s.lifecycleValidator.CheckClientDelete(req.Type, req.Id); err != nil {
+		if err := s.lifecycleValidator.CheckClientDelete(req.Type, req.Id); err != nil {
 			s.logger.Warnf("Delete denied for client (advisory): type=%s, id=%s: %v", req.Type, req.Id, err)
 			return nil, status.Errorf(codes.PermissionDenied, "%v", err)
 		}

--- a/gate/gateserver/gateserver_test.go
+++ b/gate/gateserver/gateserver_test.go
@@ -248,7 +248,8 @@ func TestGateServerRPCMethods(t *testing.T) {
 
 	t.Run("DeleteObject", func(t *testing.T) {
 		req := &gate_pb.DeleteObjectRequest{
-			Id: "test-object-1",
+			Type: "TestObj",
+			Id:   "test-object-1",
 		}
 
 		// This will return "not implemented" error from the gate

--- a/gate/gateserver/http_handler.go
+++ b/gate/gateserver/http_handler.go
@@ -297,13 +297,13 @@ func (s *GateServer) handleDeleteObject(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	// Advisory early-reject using the client-supplied type. See
-	// gateserver.go:DeleteObject — the gate can't trust the claimed
-	// type, so the authoritative check runs at the receiving node
-	// against the object's real type.
+	// Authorize on the client-supplied type via CheckClientDelete.
+	// See gateserver.go:DeleteObject — the claimed type is forwarded
+	// to the node, which verifies it matches the object's real type
+	// before deleting.
 	if s.lifecycleValidator != nil {
 		if err := s.lifecycleValidator.CheckClientDelete(objType, objID); err != nil {
-			s.logger.Warnf("Delete denied for HTTP client (advisory): type=%s, id=%s: %v", objType, objID, err)
+			s.logger.Warnf("Delete denied for HTTP client: type=%s, id=%s: %v", objType, objID, err)
 			s.writeError(w, http.StatusForbidden, "ACCESS_DENIED", err.Error())
 			return
 		}
@@ -312,9 +312,9 @@ func (s *GateServer) handleDeleteObject(w http.ResponseWriter, r *http.Request) 
 	// Create context
 	ctx := r.Context()
 
-	// Forward as a client-originated delete so the receiving node uses
-	// CheckClientDelete with the real object type.
-	err := s.cluster.DeleteClientObject(ctx, objID)
+	// Forward the claimed type so the node can verify it matches the
+	// object's real type before deleting.
+	err := s.cluster.DeleteClientObject(ctx, objType, objID)
 	if err != nil {
 		s.writeError(w, http.StatusInternalServerError, "DELETE_FAILED", err.Error())
 		return

--- a/gate/gateserver/http_handler.go
+++ b/gate/gateserver/http_handler.go
@@ -274,10 +274,10 @@ func (s *GateServer) handleCreateObject(w http.ResponseWriter, r *http.Request) 
 	s.writeJSON(w, http.StatusOK, httpResp)
 }
 
-// handleDeleteObject handles HTTP POST /api/v1/objects/delete/{type}/{id}
-// (typed, performs CheckClientDelete) and the legacy POST
-// /api/v1/objects/delete/{id} (untyped, warn-and-skip for v0.1
-// compatibility — v0.3 will reject the untyped form).
+// handleDeleteObject handles HTTP POST /api/v1/objects/delete/{type}/{id}.
+// Type is required so the gate can run its advisory CheckClientDelete
+// early-reject; the authoritative authorization happens at the
+// receiving node against the object's real type.
 func (s *GateServer) handleDeleteObject(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
 		s.writeError(w, http.StatusMethodNotAllowed, "METHOD_NOT_ALLOWED", "Only POST method is allowed")
@@ -286,17 +286,11 @@ func (s *GateServer) handleDeleteObject(w http.ResponseWriter, r *http.Request) 
 
 	path := strings.TrimPrefix(r.URL.Path, "/api/v1/objects/delete/")
 	parts := strings.SplitN(path, "/", 2)
-
-	var objType, objID string
-	switch {
-	case len(parts) == 2 && parts[0] != "" && parts[1] != "":
-		objType, objID = parts[0], parts[1]
-	case len(parts) == 1 && parts[0] != "":
-		objID = parts[0]
-	default:
-		s.writeError(w, http.StatusBadRequest, "INVALID_PARAMETERS", "Path must be /api/v1/objects/delete/{type}/{id} or /api/v1/objects/delete/{id}")
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		s.writeError(w, http.StatusBadRequest, "INVALID_PATH", "Path must be /api/v1/objects/delete/{type}/{id}")
 		return
 	}
+	objType, objID := parts[0], parts[1]
 
 	if strings.Contains(objID, "/") {
 		s.writeError(w, http.StatusBadRequest, "INVALID_PARAMETERS", "Object ID must not contain slashes")
@@ -308,9 +302,7 @@ func (s *GateServer) handleDeleteObject(w http.ResponseWriter, r *http.Request) 
 	// type, so the authoritative check runs at the receiving node
 	// against the object's real type.
 	if s.lifecycleValidator != nil {
-		if objType == "" {
-			s.logger.Warnf("DeleteObject HTTP called without type for id=%s; skipping advisory lifecycle check (v0.1 compat)", objID)
-		} else if err := s.lifecycleValidator.CheckClientDelete(objType, objID); err != nil {
+		if err := s.lifecycleValidator.CheckClientDelete(objType, objID); err != nil {
 			s.logger.Warnf("Delete denied for HTTP client (advisory): type=%s, id=%s: %v", objType, objID, err)
 			s.writeError(w, http.StatusForbidden, "ACCESS_DENIED", err.Error())
 			return

--- a/gate/gateserver/http_handler.go
+++ b/gate/gateserver/http_handler.go
@@ -303,11 +303,15 @@ func (s *GateServer) handleDeleteObject(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
+	// Advisory early-reject using the client-supplied type. See
+	// gateserver.go:DeleteObject — the gate can't trust the claimed
+	// type, so the authoritative check runs at the receiving node
+	// against the object's real type.
 	if s.lifecycleValidator != nil {
 		if objType == "" {
-			s.logger.Warnf("DeleteObject HTTP called without type for id=%s; skipping lifecycle check (v0.1 compat)", objID)
+			s.logger.Warnf("DeleteObject HTTP called without type for id=%s; skipping advisory lifecycle check (v0.1 compat)", objID)
 		} else if err := s.lifecycleValidator.CheckClientDelete(objType, objID); err != nil {
-			s.logger.Warnf("Delete denied for HTTP client: type=%s, id=%s: %v", objType, objID, err)
+			s.logger.Warnf("Delete denied for HTTP client (advisory): type=%s, id=%s: %v", objType, objID, err)
 			s.writeError(w, http.StatusForbidden, "ACCESS_DENIED", err.Error())
 			return
 		}
@@ -316,8 +320,9 @@ func (s *GateServer) handleDeleteObject(w http.ResponseWriter, r *http.Request) 
 	// Create context
 	ctx := r.Context()
 
-	// Delete the object via cluster
-	err := s.cluster.DeleteObject(ctx, objID)
+	// Forward as a client-originated delete so the receiving node uses
+	// CheckClientDelete with the real object type.
+	err := s.cluster.DeleteClientObject(ctx, objID)
 	if err != nil {
 		s.writeError(w, http.StatusInternalServerError, "DELETE_FAILED", err.Error())
 		return

--- a/gate/gateserver/http_handler.go
+++ b/gate/gateserver/http_handler.go
@@ -314,7 +314,7 @@ func (s *GateServer) handleDeleteObject(w http.ResponseWriter, r *http.Request) 
 
 	// Forward the claimed type so the node can verify it matches the
 	// object's real type before deleting.
-	err := s.cluster.DeleteClientObject(ctx, objType, objID)
+	err := s.cluster.DeleteObject(ctx, objType, objID)
 	if err != nil {
 		s.writeError(w, http.StatusInternalServerError, "DELETE_FAILED", err.Error())
 		return

--- a/gate/gateserver/http_handler.go
+++ b/gate/gateserver/http_handler.go
@@ -274,20 +274,43 @@ func (s *GateServer) handleCreateObject(w http.ResponseWriter, r *http.Request) 
 	s.writeJSON(w, http.StatusOK, httpResp)
 }
 
-// handleDeleteObject handles HTTP POST /api/v1/objects/delete/{id}
+// handleDeleteObject handles HTTP POST /api/v1/objects/delete/{type}/{id}
+// (typed, performs CheckClientDelete) and the legacy POST
+// /api/v1/objects/delete/{id} (untyped, warn-and-skip for v0.1
+// compatibility — v0.3 will reject the untyped form).
 func (s *GateServer) handleDeleteObject(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
 		s.writeError(w, http.StatusMethodNotAllowed, "METHOD_NOT_ALLOWED", "Only POST method is allowed")
 		return
 	}
 
-	// Parse URL path: /api/v1/objects/delete/{id}
 	path := strings.TrimPrefix(r.URL.Path, "/api/v1/objects/delete/")
-	objID := strings.TrimSpace(path)
+	parts := strings.SplitN(path, "/", 2)
 
-	if objID == "" || strings.Contains(objID, "/") {
-		s.writeError(w, http.StatusBadRequest, "INVALID_PARAMETERS", "Object ID must not be empty and must not contain slashes")
+	var objType, objID string
+	switch {
+	case len(parts) == 2 && parts[0] != "" && parts[1] != "":
+		objType, objID = parts[0], parts[1]
+	case len(parts) == 1 && parts[0] != "":
+		objID = parts[0]
+	default:
+		s.writeError(w, http.StatusBadRequest, "INVALID_PARAMETERS", "Path must be /api/v1/objects/delete/{type}/{id} or /api/v1/objects/delete/{id}")
 		return
+	}
+
+	if strings.Contains(objID, "/") {
+		s.writeError(w, http.StatusBadRequest, "INVALID_PARAMETERS", "Object ID must not contain slashes")
+		return
+	}
+
+	if s.lifecycleValidator != nil {
+		if objType == "" {
+			s.logger.Warnf("DeleteObject HTTP called without type for id=%s; skipping lifecycle check (v0.1 compat)", objID)
+		} else if err := s.lifecycleValidator.CheckClientDelete(objType, objID); err != nil {
+			s.logger.Warnf("Delete denied for HTTP client: type=%s, id=%s: %v", objType, objID, err)
+			s.writeError(w, http.StatusForbidden, "ACCESS_DENIED", err.Error())
+			return
+		}
 	}
 
 	// Create context

--- a/gate/gateserver/http_handler_test.go
+++ b/gate/gateserver/http_handler_test.go
@@ -215,16 +215,23 @@ func TestHandleDeleteObject_PathParsing(t *testing.T) {
 		{
 			name:           "method not allowed - GET",
 			method:         http.MethodGet,
-			path:           "/api/v1/objects/delete/obj-1",
+			path:           "/api/v1/objects/delete/Type/obj-1",
 			expectedStatus: http.StatusMethodNotAllowed,
 			expectedCode:   "METHOD_NOT_ALLOWED",
 		},
 		{
-			name:           "empty ID",
+			name:           "missing type and id",
 			method:         http.MethodPost,
 			path:           "/api/v1/objects/delete/",
 			expectedStatus: http.StatusBadRequest,
-			expectedCode:   "INVALID_PARAMETERS",
+			expectedCode:   "INVALID_PATH",
+		},
+		{
+			name:           "missing id (single segment)",
+			method:         http.MethodPost,
+			path:           "/api/v1/objects/delete/Type",
+			expectedStatus: http.StatusBadRequest,
+			expectedCode:   "INVALID_PATH",
 		},
 	}
 

--- a/gate/proto/gate.proto
+++ b/gate/proto/gate.proto
@@ -42,6 +42,11 @@ message CreateObjectResponse {
 
 message DeleteObjectRequest {
   string id = 1;
+  // type is required for the gate's CheckClientDelete access check.
+  // For backwards compatibility with v0.1 clients an empty type is
+  // accepted but logs a warning and skips the check; v0.3 will reject
+  // empty type outright.
+  string type = 2;
 }
 
 message DeleteObjectResponse {

--- a/gate/proto/gate.proto
+++ b/gate/proto/gate.proto
@@ -42,10 +42,9 @@ message CreateObjectResponse {
 
 message DeleteObjectRequest {
   string id = 1;
-  // type is required for the gate's CheckClientDelete access check.
-  // For backwards compatibility with v0.1 clients an empty type is
-  // accepted but logs a warning and skips the check; v0.3 will reject
-  // empty type outright.
+  // type is required so the gate can run its advisory
+  // CheckClientDelete early-reject. Empty type is rejected at the
+  // gate.
   string type = 2;
 }
 

--- a/goverseapi/goverseapi.go
+++ b/goverseapi/goverseapi.go
@@ -71,8 +71,8 @@ func CreateObject(ctx context.Context, objType, objID string) (string, error) {
 	return cluster.This().CreateObject(ctx, objType, objID)
 }
 
-func DeleteObject(ctx context.Context, objID string) error {
-	return cluster.This().DeleteObject(ctx, objID)
+func DeleteObject(ctx context.Context, objType, objID string) error {
+	return cluster.This().DeleteObject(ctx, objType, objID)
 }
 
 func CallObject(ctx context.Context, objType, id string, method string, request proto.Message) (proto.Message, error) {

--- a/node/node.go
+++ b/node/node.go
@@ -791,7 +791,27 @@ func (node *Node) destroyObject(id string) {
 // This operation is idempotent - if the object doesn't exist, no error is returned.
 // If the node is stopped, this operation succeeds since all objects are already cleared.
 // Returns error only if persistence deletion fails or lifecycle rules deny the deletion.
+//
+// This entry point is for node-internal callers (object-to-object,
+// runtime cleanup); the lifecycle check uses CheckNodeDelete. For
+// gate-originated deletions use DeleteClientObject so the check uses
+// CheckClientDelete with the object's real type — gate-claimed type
+// is untrusted and authorization can't be done at the gate.
 func (node *Node) DeleteObject(ctx context.Context, id string) error {
+	return node.deleteObjectImpl(ctx, id, false /* fromClient */)
+}
+
+// DeleteClientObject is the gate-originated counterpart to
+// DeleteObject. It's identical except the lifecycle check uses
+// CheckClientDelete with the real type fetched from this node's
+// object registry — closing the type-spoof gap where a client could
+// claim an allowed type to bypass an INTERNAL/REJECT rule on the
+// real type.
+func (node *Node) DeleteClientObject(ctx context.Context, id string) error {
+	return node.deleteObjectImpl(ctx, id, true /* fromClient */)
+}
+
+func (node *Node) deleteObjectImpl(ctx context.Context, id string, fromClient bool) error {
 	// Lock ordering: stopMu.RLock → per-key Lock → objectsMu
 	// Acquire read lock to prevent Stop from proceeding while this operation is in flight
 	node.stopMu.RLock()
@@ -819,11 +839,20 @@ func (node *Node) DeleteObject(ctx context.Context, id string) error {
 		return nil
 	}
 
-	// Check lifecycle rules for DELETE if lifecycle validator is configured
-	// Note: We only check here because we now know the object type
+	// Check lifecycle rules for DELETE if lifecycle validator is configured.
+	// We do this here because we now know the object's real type. For
+	// gate-originated calls, that real type is the only trustworthy
+	// input — the gate itself can't authorize on the client-supplied
+	// type without the spoof gap.
 	if node.lifecycleValidator != nil {
-		if err := node.lifecycleValidator.CheckNodeDelete(obj.Type(), id); err != nil {
-			node.logger.Warnf("Delete denied by lifecycle rules: type=%s, id=%s: %v", obj.Type(), id, err)
+		var checkErr error
+		if fromClient {
+			checkErr = node.lifecycleValidator.CheckClientDelete(obj.Type(), id)
+		} else {
+			checkErr = node.lifecycleValidator.CheckNodeDelete(obj.Type(), id)
+		}
+		if checkErr != nil {
+			node.logger.Warnf("Delete denied by lifecycle rules: type=%s, id=%s, fromClient=%v: %v", obj.Type(), id, fromClient, checkErr)
 			return fmt.Errorf("delete denied for %s/%s", obj.Type(), id)
 		}
 	}

--- a/node/node.go
+++ b/node/node.go
@@ -220,6 +220,14 @@ func (node *Node) SetLifecycleValidator(lv *config.LifecycleValidator) {
 	node.lifecycleValidator = lv
 }
 
+// LifecycleValidator returns the lifecycle validator configured on
+// this node, or nil if none is set. Used by the surrounding cluster
+// to run authorization checks at the originating side before
+// forwarding a delete to the destination node.
+func (node *Node) LifecycleValidator() *config.LifecycleValidator {
+	return node.lifecycleValidator
+}
+
 // SetClusterInfoProvider sets the consolidated cluster info provider for the node.
 // This is the preferred way to provide cluster information to the node's InspectorManager.
 // Must be called during initialization before the node is used concurrently.
@@ -790,33 +798,19 @@ func (node *Node) destroyObject(id string) {
 // This is a public method that properly handles both memory cleanup and persistence deletion.
 // This operation is idempotent - if the object doesn't exist, no error is returned.
 // If the node is stopped, this operation succeeds since all objects are already cleared.
-// Returns error only if persistence deletion fails or lifecycle rules deny the deletion.
 //
-// This entry point is for node-internal callers (object-to-object,
-// runtime cleanup); the lifecycle check uses CheckNodeDelete on the
-// object's real type. Gate-originated deletes go through
-// DeleteClientObject which threads the client-claimed type for spoof
-// verification.
-func (node *Node) DeleteObject(ctx context.Context, id string) error {
-	return node.deleteObjectImpl(ctx, id, "" /* claimedType */)
-}
-
-// DeleteClientObject is the gate-originated counterpart to
-// DeleteObject. claimedType is the type the gate received from the
-// client; the node verifies it matches the object's real type before
-// proceeding. Mismatch is rejected — closing the spoof gap where a
-// client could claim an allowed type for an id that resolves to a
-// protected object. The gate's CheckClientDelete on claimedType is
-// authoritative for authorization; this layer handles identity
-// verification only.
-func (node *Node) DeleteClientObject(ctx context.Context, claimedType, id string) error {
+// claimedType is the type the caller asserts the object has. The
+// node verifies it matches the object's real type before deleting
+// and rejects mismatches — closing the spoof gap where a client
+// could claim an allowed type for an id that resolves to a
+// protected object. Lifecycle authorization (CheckClientDelete /
+// CheckNodeDelete) is the responsibility of the caller (gate or
+// cluster.DeleteObject); this layer is identity verification only.
+func (node *Node) DeleteObject(ctx context.Context, claimedType, id string) error {
 	if claimedType == "" {
-		return fmt.Errorf("DeleteClientObject requires a non-empty claimed type")
+		return fmt.Errorf("DeleteObject requires a non-empty type")
 	}
-	return node.deleteObjectImpl(ctx, id, claimedType)
-}
 
-func (node *Node) deleteObjectImpl(ctx context.Context, id, claimedType string) error {
 	// Lock ordering: stopMu.RLock → per-key Lock → objectsMu
 	// Acquire read lock to prevent Stop from proceeding while this operation is in flight
 	node.stopMu.RLock()
@@ -844,24 +838,9 @@ func (node *Node) deleteObjectImpl(ctx context.Context, id, claimedType string) 
 		return nil
 	}
 
-	// Two-layer authorization for DELETE:
-	//   * Gate-originated path (claimedType non-empty): the gate has
-	//     already run CheckClientDelete on the client-supplied type;
-	//     here we just verify that type matches the object's real
-	//     type so a spoofed claim can't bypass the rule. If it
-	//     matches, we trust the gate's decision and proceed.
-	//   * Node-internal path (claimedType empty): no gate involved,
-	//     so we run CheckNodeDelete on the real type ourselves.
-	if claimedType != "" {
-		if obj.Type() != claimedType {
-			node.logger.Warnf("Delete rejected: claimed type=%s does not match real type=%s for id=%s", claimedType, obj.Type(), id)
-			return fmt.Errorf("delete rejected: type mismatch for %s (claimed %s, real %s)", id, claimedType, obj.Type())
-		}
-	} else if node.lifecycleValidator != nil {
-		if err := node.lifecycleValidator.CheckNodeDelete(obj.Type(), id); err != nil {
-			node.logger.Warnf("Delete denied by lifecycle rules: type=%s, id=%s: %v", obj.Type(), id, err)
-			return fmt.Errorf("delete denied for %s/%s", obj.Type(), id)
-		}
+	if obj.Type() != claimedType {
+		node.logger.Warnf("Delete rejected: claimed type=%s does not match real type=%s for id=%s", claimedType, obj.Type(), id)
+		return fmt.Errorf("delete rejected: type mismatch for %s (claimed %s, real %s)", id, claimedType, obj.Type())
 	}
 
 	// If persistence provider is configured, delete from persistence while holding the lock

--- a/node/node.go
+++ b/node/node.go
@@ -220,14 +220,6 @@ func (node *Node) SetLifecycleValidator(lv *config.LifecycleValidator) {
 	node.lifecycleValidator = lv
 }
 
-// LifecycleValidator returns the lifecycle validator configured on
-// this node, or nil if none is set. Used by the surrounding cluster
-// to run authorization checks at the originating side before
-// forwarding a delete to the destination node.
-func (node *Node) LifecycleValidator() *config.LifecycleValidator {
-	return node.lifecycleValidator
-}
-
 // SetClusterInfoProvider sets the consolidated cluster info provider for the node.
 // This is the preferred way to provide cluster information to the node's InspectorManager.
 // Must be called during initialization before the node is used concurrently.
@@ -798,14 +790,15 @@ func (node *Node) destroyObject(id string) {
 // This is a public method that properly handles both memory cleanup and persistence deletion.
 // This operation is idempotent - if the object doesn't exist, no error is returned.
 // If the node is stopped, this operation succeeds since all objects are already cleared.
+// Returns error only if persistence deletion fails or lifecycle rules deny the deletion.
 //
 // claimedType is the type the caller asserts the object has. The
 // node verifies it matches the object's real type before deleting
 // and rejects mismatches — closing the spoof gap where a client
 // could claim an allowed type for an id that resolves to a
-// protected object. Lifecycle authorization (CheckClientDelete /
-// CheckNodeDelete) is the responsibility of the caller (gate or
-// cluster.DeleteObject); this layer is identity verification only.
+// protected object. After the type matches, lifecycle rules are
+// enforced via CheckNodeDelete on that type, mirroring how
+// CreateObject runs CheckNodeCreate at this layer.
 func (node *Node) DeleteObject(ctx context.Context, claimedType, id string) error {
 	if claimedType == "" {
 		return fmt.Errorf("DeleteObject requires a non-empty type")
@@ -841,6 +834,13 @@ func (node *Node) DeleteObject(ctx context.Context, claimedType, id string) erro
 	if obj.Type() != claimedType {
 		node.logger.Warnf("Delete rejected: claimed type=%s does not match real type=%s for id=%s", claimedType, obj.Type(), id)
 		return fmt.Errorf("delete rejected: type mismatch for %s (claimed %s, real %s)", id, claimedType, obj.Type())
+	}
+
+	if node.lifecycleValidator != nil {
+		if err := node.lifecycleValidator.CheckNodeDelete(obj.Type(), id); err != nil {
+			node.logger.Warnf("Delete denied by lifecycle rules: type=%s, id=%s: %v", obj.Type(), id, err)
+			return fmt.Errorf("delete denied for %s/%s", obj.Type(), id)
+		}
 	}
 
 	// If persistence provider is configured, delete from persistence while holding the lock

--- a/node/node.go
+++ b/node/node.go
@@ -793,25 +793,30 @@ func (node *Node) destroyObject(id string) {
 // Returns error only if persistence deletion fails or lifecycle rules deny the deletion.
 //
 // This entry point is for node-internal callers (object-to-object,
-// runtime cleanup); the lifecycle check uses CheckNodeDelete. For
-// gate-originated deletions use DeleteClientObject so the check uses
-// CheckClientDelete with the object's real type — gate-claimed type
-// is untrusted and authorization can't be done at the gate.
+// runtime cleanup); the lifecycle check uses CheckNodeDelete on the
+// object's real type. Gate-originated deletes go through
+// DeleteClientObject which threads the client-claimed type for spoof
+// verification.
 func (node *Node) DeleteObject(ctx context.Context, id string) error {
-	return node.deleteObjectImpl(ctx, id, false /* fromClient */)
+	return node.deleteObjectImpl(ctx, id, "" /* claimedType */)
 }
 
 // DeleteClientObject is the gate-originated counterpart to
-// DeleteObject. It's identical except the lifecycle check uses
-// CheckClientDelete with the real type fetched from this node's
-// object registry — closing the type-spoof gap where a client could
-// claim an allowed type to bypass an INTERNAL/REJECT rule on the
-// real type.
-func (node *Node) DeleteClientObject(ctx context.Context, id string) error {
-	return node.deleteObjectImpl(ctx, id, true /* fromClient */)
+// DeleteObject. claimedType is the type the gate received from the
+// client; the node verifies it matches the object's real type before
+// proceeding. Mismatch is rejected — closing the spoof gap where a
+// client could claim an allowed type for an id that resolves to a
+// protected object. The gate's CheckClientDelete on claimedType is
+// authoritative for authorization; this layer handles identity
+// verification only.
+func (node *Node) DeleteClientObject(ctx context.Context, claimedType, id string) error {
+	if claimedType == "" {
+		return fmt.Errorf("DeleteClientObject requires a non-empty claimed type")
+	}
+	return node.deleteObjectImpl(ctx, id, claimedType)
 }
 
-func (node *Node) deleteObjectImpl(ctx context.Context, id string, fromClient bool) error {
+func (node *Node) deleteObjectImpl(ctx context.Context, id, claimedType string) error {
 	// Lock ordering: stopMu.RLock → per-key Lock → objectsMu
 	// Acquire read lock to prevent Stop from proceeding while this operation is in flight
 	node.stopMu.RLock()
@@ -839,20 +844,22 @@ func (node *Node) deleteObjectImpl(ctx context.Context, id string, fromClient bo
 		return nil
 	}
 
-	// Check lifecycle rules for DELETE if lifecycle validator is configured.
-	// We do this here because we now know the object's real type. For
-	// gate-originated calls, that real type is the only trustworthy
-	// input — the gate itself can't authorize on the client-supplied
-	// type without the spoof gap.
-	if node.lifecycleValidator != nil {
-		var checkErr error
-		if fromClient {
-			checkErr = node.lifecycleValidator.CheckClientDelete(obj.Type(), id)
-		} else {
-			checkErr = node.lifecycleValidator.CheckNodeDelete(obj.Type(), id)
+	// Two-layer authorization for DELETE:
+	//   * Gate-originated path (claimedType non-empty): the gate has
+	//     already run CheckClientDelete on the client-supplied type;
+	//     here we just verify that type matches the object's real
+	//     type so a spoofed claim can't bypass the rule. If it
+	//     matches, we trust the gate's decision and proceed.
+	//   * Node-internal path (claimedType empty): no gate involved,
+	//     so we run CheckNodeDelete on the real type ourselves.
+	if claimedType != "" {
+		if obj.Type() != claimedType {
+			node.logger.Warnf("Delete rejected: claimed type=%s does not match real type=%s for id=%s", claimedType, obj.Type(), id)
+			return fmt.Errorf("delete rejected: type mismatch for %s (claimed %s, real %s)", id, claimedType, obj.Type())
 		}
-		if checkErr != nil {
-			node.logger.Warnf("Delete denied by lifecycle rules: type=%s, id=%s, fromClient=%v: %v", obj.Type(), id, fromClient, checkErr)
+	} else if node.lifecycleValidator != nil {
+		if err := node.lifecycleValidator.CheckNodeDelete(obj.Type(), id); err != nil {
+			node.logger.Warnf("Delete denied by lifecycle rules: type=%s, id=%s: %v", obj.Type(), id, err)
 			return fmt.Errorf("delete denied for %s/%s", obj.Type(), id)
 		}
 	}

--- a/node/node_context_lifecycle_test.go
+++ b/node/node_context_lifecycle_test.go
@@ -56,7 +56,7 @@ func TestDeleteObject_CancelsObjectContext(t *testing.T) {
 	}
 
 	// Delete the object
-	err = node.DeleteObject(ctx, objID)
+	err = node.DeleteObject(ctx, "TestObjectWithContext", objID)
 	if err != nil {
 		t.Fatalf("Failed to delete object: %v", err)
 	}
@@ -118,7 +118,7 @@ func TestDeleteObject_CancelsContext_MultipleObjects(t *testing.T) {
 	ctx3 := obj3.Context()
 
 	// Delete object 2
-	err = node.DeleteObject(ctx, obj2ID)
+	err = node.DeleteObject(ctx, "TestObjectWithContext", obj2ID)
 	if err != nil {
 		t.Fatalf("Failed to delete object 2: %v", err)
 	}
@@ -147,7 +147,7 @@ func TestDeleteObject_CancelsContext_MultipleObjects(t *testing.T) {
 	}
 
 	// Delete object 1
-	err = node.DeleteObject(ctx, obj1ID)
+	err = node.DeleteObject(ctx, "TestObjectWithContext", obj1ID)
 	if err != nil {
 		t.Fatalf("Failed to delete object 1: %v", err)
 	}
@@ -231,7 +231,7 @@ func TestDeleteObject_IdempotentCancellation(t *testing.T) {
 	objCtx := obj.Context()
 
 	// Delete the object
-	err = node.DeleteObject(ctx, objID)
+	err = node.DeleteObject(ctx, "TestObjectWithContext", objID)
 	if err != nil {
 		t.Fatalf("Failed to delete object: %v", err)
 	}
@@ -245,7 +245,7 @@ func TestDeleteObject_IdempotentCancellation(t *testing.T) {
 	}
 
 	// Delete again (idempotent) - should not panic or error
-	err = node.DeleteObject(ctx, objID)
+	err = node.DeleteObject(ctx, "TestObjectWithContext", objID)
 	if err != nil {
 		t.Fatalf("Second delete should succeed (idempotent): %v", err)
 	}

--- a/node/node_delete_client_test.go
+++ b/node/node_delete_client_test.go
@@ -6,18 +6,18 @@ import (
 	"testing"
 )
 
-// TestNode_DeleteClientObject_RejectsTypeSpoof closes the spoof gap
-// codex flagged on PR #552: a client could claim an allowed type
-// (e.g. "TempSession") while supplying an id that resolves to a
-// protected object (e.g. a "TestNonPersistentObject" instance).
-// Because cluster.DeleteObject routes by id alone, the gate's
-// claimed-type authorization was vacuous on its own.
+// TestNode_DeleteObject_RejectsTypeSpoof closes the spoof gap codex
+// flagged on PR #552: a client could claim an allowed type (e.g.
+// "TempSession") while supplying an id that resolves to a protected
+// object (e.g. a "TestNonPersistentObject" instance). Because
+// cluster.DeleteObject routes by id alone, the gate's claimed-type
+// authorization was vacuous on its own.
 //
 // Fix: the gate forwards the claimed type to the receiving node;
-// node.DeleteClientObject verifies it matches the object's real
-// type from the registry. This test pins that mismatch is rejected
-// and the object survives.
-func TestNode_DeleteClientObject_RejectsTypeSpoof(t *testing.T) {
+// node.DeleteObject verifies it matches the object's real type from
+// the registry. This test pins that mismatch is rejected and the
+// object survives.
+func TestNode_DeleteObject_RejectsTypeSpoof(t *testing.T) {
 	node := NewNode("localhost:47000", testNumShards)
 	node.RegisterObjectType((*TestNonPersistentObject)(nil))
 
@@ -27,42 +27,41 @@ func TestNode_DeleteClientObject_RejectsTypeSpoof(t *testing.T) {
 		t.Fatalf("createObject: %v", err)
 	}
 
-	// Spoofed claim: real type is TestNonPersistentObject, client
-	// claims TempSession. Must be rejected.
-	err := node.DeleteClientObject(ctx, "TempSession", "protected-1")
+	// Spoofed claim: real type is TestNonPersistentObject, claim
+	// "TempSession". Must be rejected.
+	err := node.DeleteObject(ctx, "TempSession", "protected-1")
 	if err == nil {
-		t.Fatalf("DeleteClientObject succeeded with spoofed type; want type mismatch")
+		t.Fatalf("DeleteObject succeeded with spoofed type; want type mismatch")
 	}
 	if !strings.Contains(err.Error(), "type mismatch") {
-		t.Fatalf("DeleteClientObject error = %v; want \"type mismatch\"", err)
+		t.Fatalf("DeleteObject error = %v; want \"type mismatch\"", err)
 	}
 	if node.NumObjects() != 1 {
 		t.Fatalf("object should still exist after rejected spoof; NumObjects=%d", node.NumObjects())
 	}
 
 	// Honest claim with the real type goes through.
-	if err := node.DeleteClientObject(ctx, "TestNonPersistentObject", "protected-1"); err != nil {
-		t.Fatalf("DeleteClientObject with honest type failed: %v", err)
+	if err := node.DeleteObject(ctx, "TestNonPersistentObject", "protected-1"); err != nil {
+		t.Fatalf("DeleteObject with honest type failed: %v", err)
 	}
 	if node.NumObjects() != 0 {
 		t.Fatalf("object should be gone after honest delete; NumObjects=%d", node.NumObjects())
 	}
 }
 
-// TestNode_DeleteClientObject_RequiresClaimedType pins that calling
-// DeleteClientObject without a claimed type is a programming error —
-// the gate-originated path always carries the claimed type, so an
-// empty claim signals a caller bug rather than a node-internal
-// delete (which uses DeleteObject instead).
-func TestNode_DeleteClientObject_RequiresClaimedType(t *testing.T) {
+// TestNode_DeleteObject_RequiresType pins that node.DeleteObject is
+// always called with a non-empty type — it's a programming-contract
+// error to omit it (the gate / cluster layers always have type by
+// the time they reach here).
+func TestNode_DeleteObject_RequiresType(t *testing.T) {
 	node := NewNode("localhost:47000", testNumShards)
 	ctx := context.Background()
 
-	err := node.DeleteClientObject(ctx, "", "anything")
+	err := node.DeleteObject(ctx, "", "anything")
 	if err == nil {
-		t.Fatalf("DeleteClientObject with empty type succeeded; want error")
+		t.Fatalf("DeleteObject with empty type succeeded; want error")
 	}
-	if !strings.Contains(err.Error(), "non-empty claimed type") {
-		t.Fatalf("error = %v; want \"non-empty claimed type\"", err)
+	if !strings.Contains(err.Error(), "non-empty type") {
+		t.Fatalf("error = %v; want \"non-empty type\"", err)
 	}
 }

--- a/node/node_delete_client_test.go
+++ b/node/node_delete_client_test.go
@@ -1,0 +1,68 @@
+package node
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/xiaonanln/goverse/config"
+)
+
+// TestNode_DeleteClientObject_UsesRealTypeForCheck closes the spoof
+// gap codex flagged on PR #552: a client could claim an allowed type
+// (e.g. "TempSession") while supplying an id that resolves to a
+// protected object (e.g. a "TestNonPersistentObject" instance with
+// the default INTERNAL DELETE rule). Because cluster.DeleteObject
+// routes by id alone, the gate's claimed-type authorization was
+// vacuous. This test pins the fix: when the call is from a client,
+// node.DeleteClientObject authorizes against CheckClientDelete using
+// the object's *real* type as fetched from the node's registry — so
+// even with no operator rule, the default DELETE=INTERNAL semantics
+// kick in and the spoofed delete is rejected.
+func TestNode_DeleteClientObject_UsesRealTypeForCheck(t *testing.T) {
+	node := NewNode("localhost:47000", testNumShards)
+	node.RegisterObjectType((*TestNonPersistentObject)(nil))
+
+	// Operator has a permissive rule for some other type (the type
+	// the attacker claims) but the protected type has no rule, so it
+	// gets the default DELETE=INTERNAL — clients can't delete it but
+	// nodes can.
+	rules := []config.LifecycleRule{
+		{Type: "TempSession", Lifecycle: "DELETE", Access: "ALLOW"},
+	}
+	validator, err := config.NewLifecycleValidator(rules)
+	if err != nil {
+		t.Fatalf("NewLifecycleValidator: %v", err)
+	}
+	node.SetLifecycleValidator(validator)
+
+	ctx := context.Background()
+
+	if err := node.createObject(ctx, "TestNonPersistentObject", "protected-1"); err != nil {
+		t.Fatalf("createObject: %v", err)
+	}
+
+	// Spoofed client delete: the gate's vacuous "claimed-type"
+	// authorization would have let this through. The node's
+	// real-type CheckClientDelete must catch it.
+	err = node.DeleteClientObject(ctx, "protected-1")
+	if err == nil {
+		t.Fatalf("DeleteClientObject succeeded against TestNonPersistentObject under default DELETE=INTERNAL; want delete denied")
+	}
+	if !strings.Contains(err.Error(), "delete denied") {
+		t.Fatalf("DeleteClientObject error = %v; want \"delete denied\"", err)
+	}
+	if node.NumObjects() != 1 {
+		t.Fatalf("object should still exist after rejected client delete; NumObjects=%d", node.NumObjects())
+	}
+
+	// Same id via the node-internal entry point: CheckNodeDelete
+	// passes (default INTERNAL allows nodes), so the object is
+	// removed.
+	if err := node.DeleteObject(ctx, "protected-1"); err != nil {
+		t.Fatalf("internal DeleteObject failed: %v", err)
+	}
+	if node.NumObjects() != 0 {
+		t.Fatalf("object should be gone after internal delete; NumObjects=%d", node.NumObjects())
+	}
+}

--- a/node/node_delete_client_test.go
+++ b/node/node_delete_client_test.go
@@ -4,37 +4,22 @@ import (
 	"context"
 	"strings"
 	"testing"
-
-	"github.com/xiaonanln/goverse/config"
 )
 
-// TestNode_DeleteClientObject_UsesRealTypeForCheck closes the spoof
-// gap codex flagged on PR #552: a client could claim an allowed type
+// TestNode_DeleteClientObject_RejectsTypeSpoof closes the spoof gap
+// codex flagged on PR #552: a client could claim an allowed type
 // (e.g. "TempSession") while supplying an id that resolves to a
-// protected object (e.g. a "TestNonPersistentObject" instance with
-// the default INTERNAL DELETE rule). Because cluster.DeleteObject
-// routes by id alone, the gate's claimed-type authorization was
-// vacuous. This test pins the fix: when the call is from a client,
-// node.DeleteClientObject authorizes against CheckClientDelete using
-// the object's *real* type as fetched from the node's registry — so
-// even with no operator rule, the default DELETE=INTERNAL semantics
-// kick in and the spoofed delete is rejected.
-func TestNode_DeleteClientObject_UsesRealTypeForCheck(t *testing.T) {
+// protected object (e.g. a "TestNonPersistentObject" instance).
+// Because cluster.DeleteObject routes by id alone, the gate's
+// claimed-type authorization was vacuous on its own.
+//
+// Fix: the gate forwards the claimed type to the receiving node;
+// node.DeleteClientObject verifies it matches the object's real
+// type from the registry. This test pins that mismatch is rejected
+// and the object survives.
+func TestNode_DeleteClientObject_RejectsTypeSpoof(t *testing.T) {
 	node := NewNode("localhost:47000", testNumShards)
 	node.RegisterObjectType((*TestNonPersistentObject)(nil))
-
-	// Operator has a permissive rule for some other type (the type
-	// the attacker claims) but the protected type has no rule, so it
-	// gets the default DELETE=INTERNAL — clients can't delete it but
-	// nodes can.
-	rules := []config.LifecycleRule{
-		{Type: "TempSession", Lifecycle: "DELETE", Access: "ALLOW"},
-	}
-	validator, err := config.NewLifecycleValidator(rules)
-	if err != nil {
-		t.Fatalf("NewLifecycleValidator: %v", err)
-	}
-	node.SetLifecycleValidator(validator)
 
 	ctx := context.Background()
 
@@ -42,27 +27,42 @@ func TestNode_DeleteClientObject_UsesRealTypeForCheck(t *testing.T) {
 		t.Fatalf("createObject: %v", err)
 	}
 
-	// Spoofed client delete: the gate's vacuous "claimed-type"
-	// authorization would have let this through. The node's
-	// real-type CheckClientDelete must catch it.
-	err = node.DeleteClientObject(ctx, "protected-1")
+	// Spoofed claim: real type is TestNonPersistentObject, client
+	// claims TempSession. Must be rejected.
+	err := node.DeleteClientObject(ctx, "TempSession", "protected-1")
 	if err == nil {
-		t.Fatalf("DeleteClientObject succeeded against TestNonPersistentObject under default DELETE=INTERNAL; want delete denied")
+		t.Fatalf("DeleteClientObject succeeded with spoofed type; want type mismatch")
 	}
-	if !strings.Contains(err.Error(), "delete denied") {
-		t.Fatalf("DeleteClientObject error = %v; want \"delete denied\"", err)
+	if !strings.Contains(err.Error(), "type mismatch") {
+		t.Fatalf("DeleteClientObject error = %v; want \"type mismatch\"", err)
 	}
 	if node.NumObjects() != 1 {
-		t.Fatalf("object should still exist after rejected client delete; NumObjects=%d", node.NumObjects())
+		t.Fatalf("object should still exist after rejected spoof; NumObjects=%d", node.NumObjects())
 	}
 
-	// Same id via the node-internal entry point: CheckNodeDelete
-	// passes (default INTERNAL allows nodes), so the object is
-	// removed.
-	if err := node.DeleteObject(ctx, "protected-1"); err != nil {
-		t.Fatalf("internal DeleteObject failed: %v", err)
+	// Honest claim with the real type goes through.
+	if err := node.DeleteClientObject(ctx, "TestNonPersistentObject", "protected-1"); err != nil {
+		t.Fatalf("DeleteClientObject with honest type failed: %v", err)
 	}
 	if node.NumObjects() != 0 {
-		t.Fatalf("object should be gone after internal delete; NumObjects=%d", node.NumObjects())
+		t.Fatalf("object should be gone after honest delete; NumObjects=%d", node.NumObjects())
+	}
+}
+
+// TestNode_DeleteClientObject_RequiresClaimedType pins that calling
+// DeleteClientObject without a claimed type is a programming error —
+// the gate-originated path always carries the claimed type, so an
+// empty claim signals a caller bug rather than a node-internal
+// delete (which uses DeleteObject instead).
+func TestNode_DeleteClientObject_RequiresClaimedType(t *testing.T) {
+	node := NewNode("localhost:47000", testNumShards)
+	ctx := context.Background()
+
+	err := node.DeleteClientObject(ctx, "", "anything")
+	if err == nil {
+		t.Fatalf("DeleteClientObject with empty type succeeded; want error")
+	}
+	if !strings.Contains(err.Error(), "non-empty claimed type") {
+		t.Fatalf("error = %v; want \"non-empty claimed type\"", err)
 	}
 }

--- a/node/node_delete_integration_test.go
+++ b/node/node_delete_integration_test.go
@@ -51,7 +51,7 @@ func TestDeleteObject_Integration(t *testing.T) {
 	}
 
 	// Step 3: Delete the object using DeleteObject
-	err = node.DeleteObject(ctx, "integration-test-obj")
+	err = node.DeleteObject(ctx, "TestPersistentObject", "integration-test-obj")
 	if err != nil {
 		t.Fatalf("Failed to delete object: %v", err)
 	}
@@ -67,7 +67,7 @@ func TestDeleteObject_Integration(t *testing.T) {
 	}
 
 	// Step 6: Verify deletion is idempotent - can delete non-existent object without error
-	err = node.DeleteObject(ctx, "integration-test-obj")
+	err = node.DeleteObject(ctx, "TestPersistentObject", "integration-test-obj")
 	if err != nil {
 		t.Fatalf("Expected no error when deleting already-deleted object (idempotent), got: %v", err)
 	}
@@ -107,7 +107,7 @@ func TestDeleteObject_Integration_NonPersistent(t *testing.T) {
 	}
 
 	// Step 2: Delete the object
-	err = node.DeleteObject(ctx, "non-persist-integration-obj")
+	err = node.DeleteObject(ctx, "TestNonPersistentObject", "non-persist-integration-obj")
 	if err != nil {
 		t.Fatalf("Failed to delete non-persistent object: %v", err)
 	}
@@ -183,13 +183,13 @@ func TestDeleteObject_Integration_MixedObjects(t *testing.T) {
 	}
 
 	// Delete one persistent object
-	err = node.DeleteObject(ctx, "persist-2")
+	err = node.DeleteObject(ctx, "TestPersistentObject", "persist-2")
 	if err != nil {
 		t.Fatalf("Failed to delete persistent object: %v", err)
 	}
 
 	// Delete one non-persistent object
-	err = node.DeleteObject(ctx, "non-persist-1")
+	err = node.DeleteObject(ctx, "TestNonPersistentObject", "non-persist-1")
 	if err != nil {
 		t.Fatalf("Failed to delete non-persistent object: %v", err)
 	}

--- a/node/node_delete_test.go
+++ b/node/node_delete_test.go
@@ -45,7 +45,7 @@ func TestNode_DeleteObject_PersistentObject(t *testing.T) {
 	}
 
 	// Delete the object
-	err = node.DeleteObject(ctx, "delete-obj-1")
+	err = node.DeleteObject(ctx, "TestPersistentObject", "delete-obj-1")
 	if err != nil {
 		t.Fatalf("Failed to delete object: %v", err)
 	}
@@ -89,7 +89,7 @@ func TestNode_DeleteObject_NonPersistentObject(t *testing.T) {
 	}
 
 	// Delete the object
-	err = node.DeleteObject(ctx, "non-persist-obj")
+	err = node.DeleteObject(ctx, "TestNonPersistentObject", "non-persist-obj")
 	if err != nil {
 		t.Fatalf("Failed to delete non-persistent object: %v", err)
 	}
@@ -133,7 +133,7 @@ func TestNode_DeleteObject_NoProvider(t *testing.T) {
 	}
 
 	// Delete the object (should work even without persistence provider)
-	err = node.DeleteObject(ctx, "no-provider-obj")
+	err = node.DeleteObject(ctx, "TestPersistentObject", "no-provider-obj")
 	if err != nil {
 		t.Fatalf("Failed to delete object without provider: %v", err)
 	}
@@ -154,7 +154,7 @@ func TestNode_DeleteObject_NotFound(t *testing.T) {
 	ctx := context.Background()
 
 	// Try to delete non-existent object - should succeed (idempotent)
-	err := node.DeleteObject(ctx, "non-existent-obj")
+	err := node.DeleteObject(ctx, "TestPersistentObject", "non-existent-obj")
 	if err != nil {
 		t.Fatalf("Expected no error for idempotent delete of non-existent object, got: %v", err)
 	}
@@ -246,7 +246,7 @@ func TestNode_DeleteObject_MultipleObjects(t *testing.T) {
 	}
 
 	// Delete one object
-	err = node.DeleteObject(ctx, "multi-obj-3")
+	err = node.DeleteObject(ctx, "TestPersistentObject", "multi-obj-3")
 	if err != nil {
 		t.Fatalf("Failed to delete object: %v", err)
 	}
@@ -276,7 +276,7 @@ func TestNode_DeleteObject_MultipleObjects(t *testing.T) {
 	}
 
 	// Delete another object
-	err = node.DeleteObject(ctx, "multi-obj-1")
+	err = node.DeleteObject(ctx, "TestPersistentObject", "multi-obj-1")
 	if err != nil {
 		t.Fatalf("Failed to delete second object: %v", err)
 	}
@@ -326,7 +326,7 @@ func TestNode_DeleteObject_ThreadSafety(t *testing.T) {
 	for i := 0; i < objectCount; i++ {
 		go func(idx int) {
 			objID := fmt.Sprintf("thread-obj-%d", idx)
-			_ = node.DeleteObject(ctx, objID)
+			_ = node.DeleteObject(ctx, "TestPersistentObject", objID)
 			done <- true
 		}(i)
 	}

--- a/node/node_keylock_integration_test.go
+++ b/node/node_keylock_integration_test.go
@@ -45,7 +45,7 @@ func TestKeyLockIntegration_CreateDeleteRace(t *testing.T) {
 					successCount.Add(1)
 
 					// Delete it
-					err = node.DeleteObject(ctx, objID)
+					err = node.DeleteObject(ctx, "TestPersistentObject", objID)
 					if err != nil {
 						// Object might have been deleted by another goroutine
 						t.Logf("Delete failed: %v", err)
@@ -121,7 +121,7 @@ func TestKeyLockIntegration_CallDuringDelete(t *testing.T) {
 	go func() {
 		defer wg.Done()
 		time.Sleep(50 * time.Millisecond) // Let some calls happen first
-		err := node.DeleteObject(ctx, "call-delete-obj")
+		err := node.DeleteObject(ctx, "TestPersistentObjectWithMethod", "call-delete-obj")
 		if err != nil {
 			t.Logf("Delete error: %v", err)
 		}
@@ -182,7 +182,7 @@ func TestKeyLockIntegration_SaveDuringDelete(t *testing.T) {
 		defer wg.Done()
 		time.Sleep(20 * time.Millisecond)
 		for i := 0; i < 5; i++ {
-			err := node.DeleteObject(ctx, "save-delete-obj")
+			err := node.DeleteObject(ctx, "TestPersistentObject", "save-delete-obj")
 			if err != nil {
 				t.Logf("Delete error: %v", err)
 			}
@@ -289,7 +289,7 @@ func TestKeyLockIntegration_CreateCallDeleteSequence(t *testing.T) {
 		}
 
 		// Delete
-		err = node.DeleteObject(ctx, objID)
+		err = node.DeleteObject(ctx, "TestPersistentObjectWithMethod", objID)
 		if err != nil {
 			t.Fatalf("Failed to delete object: %v", err)
 		}
@@ -328,7 +328,7 @@ func TestKeyLockIntegration_NoLockLeaks(t *testing.T) {
 			// Wait for object to be created (CreateObject is async)
 			waitForObjectCreated(t, node, objID, 5*time.Second)
 
-			err = node.DeleteObject(ctx, objID)
+			err = node.DeleteObject(ctx, "TestPersistentObject", objID)
 			if err != nil {
 				t.Logf("Delete error: %v", err)
 			}

--- a/node/node_serialization_test.go
+++ b/node/node_serialization_test.go
@@ -76,7 +76,7 @@ func TestObjectLifecycleSerialization(t *testing.T) {
 			objID := "serial-delete-obj"
 			// Create the object first
 			node.createObject(ctx, "TestPersistentObject", objID)
-			err := node.DeleteObject(ctx, objID)
+			err := node.DeleteObject(ctx, "TestPersistentObject", objID)
 			if err == nil {
 				countMu.Lock()
 				deleteCount++
@@ -278,7 +278,7 @@ func TestDeleteObjectSerializesWithCallObject(t *testing.T) {
 		go func() {
 			defer wg.Done()
 			time.Sleep(5 * time.Millisecond)
-			err := node.DeleteObject(ctx, objID)
+			err := node.DeleteObject(ctx, "TestPersistentObjectWithMethod", objID)
 			if err == nil {
 				countMu.Lock()
 				deleteSuccessCount++

--- a/node/node_stop_race_test.go
+++ b/node/node_stop_race_test.go
@@ -217,7 +217,7 @@ func TestStop_RaceWithDeleteObject(t *testing.T) {
 			if index > 5 {
 				time.Sleep(10 * time.Millisecond)
 			}
-			err := node.DeleteObject(ctx, "delete-race-obj")
+			err := node.DeleteObject(ctx, "TestPersistentObject", "delete-race-obj")
 			results <- err
 		}(i)
 	}
@@ -396,7 +396,7 @@ func TestStop_NoNewOperationsAfterStop(t *testing.T) {
 	// Try DeleteObject - should succeed (idempotent: node stopped = objects cleared)
 	// Unlike other operations, DeleteObject succeeds when node is stopped because
 	// the desired state (object not existing) is already achieved
-	err = node.DeleteObject(ctx, "after-stop-obj")
+	err = node.DeleteObject(ctx, "TestPersistentObject", "after-stop-obj")
 	if err != nil {
 		t.Fatalf("Expected DeleteObject to succeed after stop (idempotent), got error: %v", err)
 	}

--- a/proto/goverse.proto
+++ b/proto/goverse.proto
@@ -47,13 +47,11 @@ message CreateObjectResponse {
 
 message DeleteObjectRequest {
   string id = 1;
-  // type carries the object type the gate received from the client.
-  // When non-empty (gate-originated path) the receiving node verifies
-  // it matches the object's real type and rejects mismatches —
-  // closing the spoof gap where a client could claim an allowed type
-  // for an id that resolves to a protected object. When empty
-  // (node-internal path) the node falls back to its own
-  // CheckNodeDelete on the real type.
+  // type is the object type the caller asserts. The receiving node
+  // verifies it matches the object's real type and rejects
+  // mismatches — closing the spoof gap where a client could claim an
+  // allowed type for an id that resolves to a protected object.
+  // Required.
   string type = 2;
 }
 

--- a/proto/goverse.proto
+++ b/proto/goverse.proto
@@ -47,12 +47,14 @@ message CreateObjectResponse {
 
 message DeleteObjectRequest {
   string id = 1;
-  // from_client signals that the call originated from a Gate-facing
-  // client (rather than a node-to-node hop). The receiving node uses
-  // it to pick CheckClientDelete vs CheckNodeDelete with the object's
-  // real type — the type the gate received from the client is
-  // untrusted, so authorization can't be done at the gate.
-  bool from_client = 2;
+  // type carries the object type the gate received from the client.
+  // When non-empty (gate-originated path) the receiving node verifies
+  // it matches the object's real type and rejects mismatches —
+  // closing the spoof gap where a client could claim an allowed type
+  // for an id that resolves to a protected object. When empty
+  // (node-internal path) the node falls back to its own
+  // CheckNodeDelete on the real type.
+  string type = 2;
 }
 
 message DeleteObjectResponse {

--- a/proto/goverse.proto
+++ b/proto/goverse.proto
@@ -47,6 +47,12 @@ message CreateObjectResponse {
 
 message DeleteObjectRequest {
   string id = 1;
+  // from_client signals that the call originated from a Gate-facing
+  // client (rather than a node-to-node hop). The receiving node uses
+  // it to pick CheckClientDelete vs CheckNodeDelete with the object's
+  // real type — the type the gate received from the client is
+  // untrusted, so authorization can't be done at the gate.
+  bool from_client = 2;
 }
 
 message DeleteObjectResponse {

--- a/server/server.go
+++ b/server/server.go
@@ -532,8 +532,8 @@ func (server *Server) DeleteObject(ctx context.Context, req *goverse_pb.DeleteOb
 	}
 
 	var err error
-	if req.GetFromClient() {
-		err = server.Node.DeleteClientObject(ctx, req.GetId())
+	if claimedType := req.GetType(); claimedType != "" {
+		err = server.Node.DeleteClientObject(ctx, claimedType, req.GetId())
 	} else {
 		err = server.Node.DeleteObject(ctx, req.GetId())
 	}

--- a/server/server.go
+++ b/server/server.go
@@ -531,7 +531,12 @@ func (server *Server) DeleteObject(ctx context.Context, req *goverse_pb.DeleteOb
 		}
 	}
 
-	err := server.Node.DeleteObject(ctx, req.GetId())
+	var err error
+	if req.GetFromClient() {
+		err = server.Node.DeleteClientObject(ctx, req.GetId())
+	} else {
+		err = server.Node.DeleteObject(ctx, req.GetId())
+	}
 	if err != nil {
 		server.logger.Errorf("DeleteObject failed: %v", err)
 		return nil, err

--- a/server/server.go
+++ b/server/server.go
@@ -531,12 +531,7 @@ func (server *Server) DeleteObject(ctx context.Context, req *goverse_pb.DeleteOb
 		}
 	}
 
-	var err error
-	if claimedType := req.GetType(); claimedType != "" {
-		err = server.Node.DeleteClientObject(ctx, claimedType, req.GetId())
-	} else {
-		err = server.Node.DeleteObject(ctx, req.GetId())
-	}
+	err := server.Node.DeleteObject(ctx, req.GetType(), req.GetId())
 	if err != nil {
 		server.logger.Errorf("DeleteObject failed: %v", err)
 		return nil, err

--- a/server/server_delete_test.go
+++ b/server/server_delete_test.go
@@ -49,7 +49,8 @@ func TestServerDeleteObject_Success(t *testing.T) {
 
 	// Delete the object
 	deleteReq := &goverse_pb.DeleteObjectRequest{
-		Id: "test-delete-obj",
+		Type: "TestObject",
+		Id:   "test-delete-obj",
 	}
 	_, err = server.DeleteObject(ctx, deleteReq)
 	if err != nil {
@@ -128,7 +129,8 @@ func TestServerDeleteObject_NotFound(t *testing.T) {
 
 	// Try to delete non-existent object
 	deleteReq := &goverse_pb.DeleteObjectRequest{
-		Id: "non-existent-obj",
+		Type: "TestObject",
+		Id:   "non-existent-obj",
 	}
 	_, err := server.DeleteObject(ctx, deleteReq)
 	if err != nil {

--- a/tests/samples/counter/test_counter.py
+++ b/tests/samples/counter/test_counter.py
@@ -225,7 +225,7 @@ def call_reset(counter_name, http_port):
 
 def call_delete(counter_name, http_port):
     """Call the Delete method via HTTP REST API."""
-    url = f'http://localhost:{http_port}/api/v1/objects/delete/Counter-{counter_name}'
+    url = f'http://localhost:{http_port}/api/v1/objects/delete/Counter/Counter-{counter_name}'
     http_post(url)
     return True
 

--- a/util/testutil/test_server_helper.go
+++ b/util/testutil/test_server_helper.go
@@ -118,7 +118,7 @@ func (tsh *TestServerHelper) GetAddress() string {
 type nodeInterface interface {
 	CreateObject(ctx context.Context, typ string, id string) (string, error)
 	CallObject(ctx context.Context, typ string, id string, method string, request proto.Message) (proto.Message, error)
-	DeleteObject(ctx context.Context, id string) error
+	DeleteObject(ctx context.Context, typ string, id string) error
 	ReliableCallObject(ctx context.Context, callID string, objectType string, objectID string, methodName string, request *anypb.Any) (*anypb.Any, goverse_pb.ReliableCallStatus, error)
 }
 
@@ -256,7 +256,7 @@ func (m *MockGoverseServer) DeleteObject(ctx context.Context, req *goverse_pb.De
 	}
 
 	// Call DeleteObject on the actual node
-	err := node.DeleteObject(ctx, req.Id)
+	err := node.DeleteObject(ctx, req.Type, req.Id)
 	if err != nil {
 		return nil, fmt.Errorf("failed to delete object: %v", err)
 	}


### PR DESCRIPTION
## Summary

- Wire `LifecycleValidator.CheckClientDelete` into both the gRPC `DeleteObject` handler and the HTTP delete route. Before this, `CheckClientDelete` had zero call sites in production code, so `object_lifecycle_rules` DELETE rules were silently unenforced and any client could delete any object.
- Extend `gate.proto`'s `DeleteObjectRequest` with an optional `type` field so the gate has the second argument the check requires.
- Add a new typed HTTP route `POST /api/v1/objects/delete/{type}/{id}`. The legacy untyped route `POST /api/v1/objects/delete/{id}` keeps working but warn-and-skips the lifecycle check during the v0.1 → v0.2 upgrade window. v0.3 will reject empty type outright.
- Bump the Go and Python client `DeleteObject` / `delete_object` signatures to take type as the first arg — a v0.2 minor-bump-shaped breaking change called out in the design doc.

## Why

This is item 4 of `docs/design/V0_2_TRUST_BOUNDARY.md` — the v0.2 trust-boundary plan's "smallest, mostly mechanical" first cut. PR #549 did the equivalent fix for `CheckClientCreate` on the HTTP create handler; this closes the symmetric DELETE gap.

## Test plan

- [ ] `go test ./gate/gateserver/ ./client/goverseclient/ ./config/` — passes locally.
- [ ] New tests in `gate/gateserver/delete_access_test.go`:
  - `TestHandleDeleteObject_LifecycleRejected` — typed HTTP path with INTERNAL DELETE rule returns 403.
  - `TestHandleDeleteObject_LegacyUntypedSkipsCheck` — legacy untyped path bypasses the rule (warn-and-skip).
  - `TestDeleteObject_gRPC_LifecycleRejected` — gRPC handler returns `PermissionDenied`.
- [ ] CI re-runs `compile-proto.sh` (via `setup-test-env`) so generated `.pb.go` matches the new proto.