### PR TITLE
feat: pluggable auth middleware + CallerIdentity context (v0.2 item 2)

### DIFF
--- a/gate/gateserver/gateserver.go
+++ b/gate/gateserver/gateserver.go
@@ -335,6 +335,19 @@ func (s *GateServer) CallObject(ctx context.Context, req *gate_pb.CallObjectRequ
 		}
 	}
 
+	// When auth is configured, reject calls whose client_id is absent or does
+	// not correspond to an active authenticated Register session. This prevents
+	// a caller from supplying an arbitrary (or guessed) client_id to impersonate
+	// another user's identity.
+	if s.authValidator != nil {
+		if req.ClientId == "" {
+			return nil, status.Errorf(codes.Unauthenticated, "client_id required when auth is configured")
+		}
+		if _, ok := s.clientIdentities.Load(req.ClientId); !ok {
+			return nil, status.Errorf(codes.Unauthenticated, "client_id does not match an authenticated session")
+		}
+	}
+
 	// Inject client_id into the context so it can be passed to the node
 	if req.ClientId != "" {
 		ctx = callcontext.WithClientID(ctx, req.ClientId)

--- a/gate/gateserver/gateserver.go
+++ b/gate/gateserver/gateserver.go
@@ -2,6 +2,8 @@ package gateserver
 
 import (
 	"context"
+	"crypto/rand"
+	"encoding/hex"
 	"fmt"
 	"net"
 	"net/http"
@@ -23,6 +25,15 @@ import (
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/anypb"
 )
+
+// clientSession holds the authenticated identity and the per-connection session
+// token for a registered client. The token is sent to the client inside
+// RegisterResponse and must be echoed back as "x-session-token" gRPC metadata
+// on every CallObject request — proving the caller owns the Register stream.
+type clientSession struct {
+	identity     *callcontext.CallerIdentity
+	sessionToken string
+}
 
 // GateServerConfig holds configuration for the gate server
 type GateServerConfig struct {
@@ -65,10 +76,10 @@ type GateServer struct {
 	cluster            *cluster.Cluster
 	accessValidator    *config.AccessValidator
 	lifecycleValidator *config.LifecycleValidator
-	authValidator      callcontext.AuthValidator
-	// clientIdentities maps clientID → *callcontext.CallerIdentity for authenticated connections.
-	// Written on Register, deleted on disconnect, read on every CallObject.
-	clientIdentities   sync.Map
+	authValidator callcontext.AuthValidator
+	// clientSessions maps clientID → clientSession for authenticated connections.
+	// Written on Register, deleted on disconnect, verified on every CallObject.
+	clientSessions sync.Map
 	stopMu             sync.RWMutex
 	stopped            atomic.Bool
 }
@@ -258,13 +269,20 @@ func (s *GateServer) Register(req *gate_pb.Empty, stream grpc.ServerStreamingSer
 
 	// Validate auth if a validator is configured. Extract gRPC metadata so
 	// the validator can read e.g. "authorization" for a bearer token.
-	var identity *callcontext.CallerIdentity
+	var session *clientSession
 	if s.authValidator != nil {
 		md, _ := metadata.FromIncomingContext(ctx)
-		var err error
-		identity, err = s.authValidator.Validate(ctx, md)
+		identity, err := s.authValidator.Validate(ctx, md)
 		if err != nil {
 			return status.Errorf(codes.Unauthenticated, "%v", err)
+		}
+		tokenBytes := make([]byte, 32)
+		if _, err := rand.Read(tokenBytes); err != nil {
+			return status.Errorf(codes.Internal, "failed to generate session token: %v", err)
+		}
+		session = &clientSession{
+			identity:     identity,
+			sessionToken: hex.EncodeToString(tokenBytes),
 		}
 	}
 
@@ -274,14 +292,17 @@ func (s *GateServer) Register(req *gate_pb.Empty, stream grpc.ServerStreamingSer
 	// Make sure to unregister when done
 	defer s.gate.Unregister(clientID)
 
-	// Store identity so CallObject can inject it into the call context.
-	if identity != nil {
-		s.clientIdentities.Store(clientID, identity)
-		defer s.clientIdentities.Delete(clientID)
+	// Store session so CallObject can verify ownership and inject identity.
+	if session != nil {
+		s.clientSessions.Store(clientID, session)
+		defer s.clientSessions.Delete(clientID)
 	}
 
-	// Send RegisterResponse
+	// Send RegisterResponse (includes session_token when auth is configured)
 	regResp := &gate_pb.RegisterResponse{ClientId: clientID}
+	if session != nil {
+		regResp.SessionToken = session.sessionToken
+	}
 	anyResp, err := protohelper.MsgToAny(regResp)
 	if err != nil {
 		return fmt.Errorf("failed to marshal RegisterResponse: %w", err)
@@ -335,16 +356,23 @@ func (s *GateServer) CallObject(ctx context.Context, req *gate_pb.CallObjectRequ
 		}
 	}
 
-	// When auth is configured, reject calls whose client_id is absent or does
-	// not correspond to an active authenticated Register session. This prevents
-	// a caller from supplying an arbitrary (or guessed) client_id to impersonate
-	// another user's identity.
+	// When auth is configured, verify the caller owns the Register session for
+	// req.ClientId by checking the session token sent as "x-session-token"
+	// metadata. This closes the impersonation gap: knowing another client's ID
+	// is not sufficient without also holding the token issued at Register time.
 	if s.authValidator != nil {
 		if req.ClientId == "" {
 			return nil, status.Errorf(codes.Unauthenticated, "client_id required when auth is configured")
 		}
-		if _, ok := s.clientIdentities.Load(req.ClientId); !ok {
+		v, ok := s.clientSessions.Load(req.ClientId)
+		if !ok {
 			return nil, status.Errorf(codes.Unauthenticated, "client_id does not match an authenticated session")
+		}
+		sess := v.(*clientSession)
+		md, _ := metadata.FromIncomingContext(ctx)
+		tokens := md["x-session-token"]
+		if len(tokens) == 0 || tokens[0] != sess.sessionToken {
+			return nil, status.Errorf(codes.Unauthenticated, "missing or invalid x-session-token")
 		}
 	}
 
@@ -353,9 +381,9 @@ func (s *GateServer) CallObject(ctx context.Context, req *gate_pb.CallObjectRequ
 		ctx = callcontext.WithClientID(ctx, req.ClientId)
 	}
 
-	// Inject caller identity if the client has an authenticated connection.
-	if v, ok := s.clientIdentities.Load(req.ClientId); ok {
-		ctx = callcontext.WithCallerIdentity(ctx, v.(*callcontext.CallerIdentity))
+	// Inject caller identity if the client has an authenticated session.
+	if v, ok := s.clientSessions.Load(req.ClientId); ok {
+		ctx = callcontext.WithCallerIdentity(ctx, v.(*clientSession).identity)
 	}
 
 	// Use CallObjectAnyRequest to pass Any directly without unmarshaling (optimization)

--- a/gate/gateserver/gateserver.go
+++ b/gate/gateserver/gateserver.go
@@ -2,8 +2,6 @@ package gateserver
 
 import (
 	"context"
-	"crypto/rand"
-	"encoding/hex"
 	"fmt"
 	"net"
 	"net/http"
@@ -25,15 +23,6 @@ import (
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/anypb"
 )
-
-// clientSession holds the authenticated identity and the per-connection session
-// token for a registered client. The token is sent to the client inside
-// RegisterResponse and must be echoed back as "x-session-token" gRPC metadata
-// on every CallObject request — proving the caller owns the Register stream.
-type clientSession struct {
-	identity     *callcontext.CallerIdentity
-	sessionToken string
-}
 
 // GateServerConfig holds configuration for the gate server
 type GateServerConfig struct {
@@ -76,10 +65,10 @@ type GateServer struct {
 	cluster            *cluster.Cluster
 	accessValidator    *config.AccessValidator
 	lifecycleValidator *config.LifecycleValidator
-	authValidator callcontext.AuthValidator
-	// clientSessions maps clientID → clientSession for authenticated connections.
-	// Written on Register, deleted on disconnect, verified on every CallObject.
-	clientSessions sync.Map
+	authValidator      callcontext.AuthValidator
+	// clientIdentities maps clientID → *callcontext.CallerIdentity for authenticated connections.
+	// Written on Register, deleted on disconnect, read on every CallObject.
+	clientIdentities   sync.Map
 	stopMu             sync.RWMutex
 	stopped            atomic.Bool
 }
@@ -269,20 +258,13 @@ func (s *GateServer) Register(req *gate_pb.Empty, stream grpc.ServerStreamingSer
 
 	// Validate auth if a validator is configured. Extract gRPC metadata so
 	// the validator can read e.g. "authorization" for a bearer token.
-	var session *clientSession
+	var identity *callcontext.CallerIdentity
 	if s.authValidator != nil {
 		md, _ := metadata.FromIncomingContext(ctx)
-		identity, err := s.authValidator.Validate(ctx, md)
+		var err error
+		identity, err = s.authValidator.Validate(ctx, md)
 		if err != nil {
 			return status.Errorf(codes.Unauthenticated, "%v", err)
-		}
-		tokenBytes := make([]byte, 32)
-		if _, err := rand.Read(tokenBytes); err != nil {
-			return status.Errorf(codes.Internal, "failed to generate session token: %v", err)
-		}
-		session = &clientSession{
-			identity:     identity,
-			sessionToken: hex.EncodeToString(tokenBytes),
 		}
 	}
 
@@ -292,17 +274,14 @@ func (s *GateServer) Register(req *gate_pb.Empty, stream grpc.ServerStreamingSer
 	// Make sure to unregister when done
 	defer s.gate.Unregister(clientID)
 
-	// Store session so CallObject can verify ownership and inject identity.
-	if session != nil {
-		s.clientSessions.Store(clientID, session)
-		defer s.clientSessions.Delete(clientID)
+	// Store identity so CallObject can inject it into the call context.
+	if identity != nil {
+		s.clientIdentities.Store(clientID, identity)
+		defer s.clientIdentities.Delete(clientID)
 	}
 
-	// Send RegisterResponse (includes session_token when auth is configured)
+	// Send RegisterResponse
 	regResp := &gate_pb.RegisterResponse{ClientId: clientID}
-	if session != nil {
-		regResp.SessionToken = session.sessionToken
-	}
 	anyResp, err := protohelper.MsgToAny(regResp)
 	if err != nil {
 		return fmt.Errorf("failed to marshal RegisterResponse: %w", err)
@@ -356,23 +335,16 @@ func (s *GateServer) CallObject(ctx context.Context, req *gate_pb.CallObjectRequ
 		}
 	}
 
-	// When auth is configured, verify the caller owns the Register session for
-	// req.ClientId by checking the session token sent as "x-session-token"
-	// metadata. This closes the impersonation gap: knowing another client's ID
-	// is not sufficient without also holding the token issued at Register time.
+	// When auth is configured, reject calls whose client_id is absent or does
+	// not correspond to an active authenticated Register session. This prevents
+	// a caller from supplying an arbitrary (or guessed) client_id to impersonate
+	// another user's identity.
 	if s.authValidator != nil {
 		if req.ClientId == "" {
 			return nil, status.Errorf(codes.Unauthenticated, "client_id required when auth is configured")
 		}
-		v, ok := s.clientSessions.Load(req.ClientId)
-		if !ok {
+		if _, ok := s.clientIdentities.Load(req.ClientId); !ok {
 			return nil, status.Errorf(codes.Unauthenticated, "client_id does not match an authenticated session")
-		}
-		sess := v.(*clientSession)
-		md, _ := metadata.FromIncomingContext(ctx)
-		tokens := md["x-session-token"]
-		if len(tokens) == 0 || tokens[0] != sess.sessionToken {
-			return nil, status.Errorf(codes.Unauthenticated, "missing or invalid x-session-token")
 		}
 	}
 
@@ -381,9 +353,9 @@ func (s *GateServer) CallObject(ctx context.Context, req *gate_pb.CallObjectRequ
 		ctx = callcontext.WithClientID(ctx, req.ClientId)
 	}
 
-	// Inject caller identity if the client has an authenticated session.
-	if v, ok := s.clientSessions.Load(req.ClientId); ok {
-		ctx = callcontext.WithCallerIdentity(ctx, v.(*clientSession).identity)
+	// Inject caller identity if the client has an authenticated connection.
+	if v, ok := s.clientIdentities.Load(req.ClientId); ok {
+		ctx = callcontext.WithCallerIdentity(ctx, v.(*callcontext.CallerIdentity))
 	}
 
 	// Use CallObjectAnyRequest to pass Any directly without unmarshaling (optimization)

--- a/gate/gateserver/gateserver.go
+++ b/gate/gateserver/gateserver.go
@@ -18,6 +18,7 @@ import (
 	"github.com/xiaonanln/goverse/util/protohelper"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/reflection"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/anypb"
@@ -43,6 +44,10 @@ type GateServerConfig struct {
 	AccessValidator    *config.AccessValidator    // Optional: access validator for client access control
 	LifecycleValidator *config.LifecycleValidator // Optional: lifecycle validator for CREATE/DELETE control
 
+	// AuthValidator validates client credentials on Register. When nil, all
+	// connections are accepted without authentication (v0.1 behaviour).
+	AuthValidator callcontext.AuthValidator
+
 	ConfigFile *config.Config // Optional: loaded config file (if config file was used)
 }
 
@@ -60,6 +65,10 @@ type GateServer struct {
 	cluster            *cluster.Cluster
 	accessValidator    *config.AccessValidator
 	lifecycleValidator *config.LifecycleValidator
+	authValidator      callcontext.AuthValidator
+	// clientIdentities maps clientID → *callcontext.CallerIdentity for authenticated connections.
+	// Written on Register, deleted on disconnect, read on every CallObject.
+	clientIdentities   sync.Map
 	stopMu             sync.RWMutex
 	stopped            atomic.Bool
 }
@@ -108,6 +117,7 @@ func NewGateServer(config *GateServerConfig) (*GateServer, error) {
 		cluster:            c,
 		accessValidator:    config.AccessValidator,
 		lifecycleValidator: config.LifecycleValidator,
+		authValidator:      config.AuthValidator,
 	}
 
 	return server, nil
@@ -245,11 +255,30 @@ func (s *GateServer) Register(req *gate_pb.Empty, stream grpc.ServerStreamingSer
 	}
 
 	ctx := stream.Context()
+
+	// Validate auth if a validator is configured. Extract gRPC metadata so
+	// the validator can read e.g. "authorization" for a bearer token.
+	var identity *callcontext.CallerIdentity
+	if s.authValidator != nil {
+		md, _ := metadata.FromIncomingContext(ctx)
+		var err error
+		identity, err = s.authValidator.Validate(ctx, md)
+		if err != nil {
+			return status.Errorf(codes.Unauthenticated, "%v", err)
+		}
+	}
+
 	clientProxy := s.gate.Register(ctx)
 	clientID := clientProxy.GetID()
 
 	// Make sure to unregister when done
 	defer s.gate.Unregister(clientID)
+
+	// Store identity so CallObject can inject it into the call context.
+	if identity != nil {
+		s.clientIdentities.Store(clientID, identity)
+		defer s.clientIdentities.Delete(clientID)
+	}
 
 	// Send RegisterResponse
 	regResp := &gate_pb.RegisterResponse{ClientId: clientID}
@@ -309,6 +338,11 @@ func (s *GateServer) CallObject(ctx context.Context, req *gate_pb.CallObjectRequ
 	// Inject client_id into the context so it can be passed to the node
 	if req.ClientId != "" {
 		ctx = callcontext.WithClientID(ctx, req.ClientId)
+	}
+
+	// Inject caller identity if the client has an authenticated connection.
+	if v, ok := s.clientIdentities.Load(req.ClientId); ok {
+		ctx = callcontext.WithCallerIdentity(ctx, v.(*callcontext.CallerIdentity))
 	}
 
 	// Use CallObjectAnyRequest to pass Any directly without unmarshaling (optimization)

--- a/gate/gateserver/gateserver_auth_test.go
+++ b/gate/gateserver/gateserver_auth_test.go
@@ -1,0 +1,117 @@
+package gateserver
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	gate_pb "github.com/xiaonanln/goverse/gate/proto"
+	"github.com/xiaonanln/goverse/util/callcontext"
+	"github.com/xiaonanln/goverse/util/testutil"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/status"
+)
+
+type stubAuthValidator struct {
+	identity *callcontext.CallerIdentity
+	err      error
+}
+
+func (s *stubAuthValidator) Validate(_ context.Context, _ map[string][]string) (*callcontext.CallerIdentity, error) {
+	return s.identity, s.err
+}
+
+func authGateServer(t *testing.T, prefix string, validator callcontext.AuthValidator) (*GateServer, gate_pb.GateServiceClient) {
+	t.Helper()
+	listenAddr := testutil.GetFreeAddress()
+	cfg := &GateServerConfig{
+		ListenAddress:    listenAddr,
+		AdvertiseAddress: listenAddr,
+		EtcdAddress:      "localhost:2379",
+		EtcdPrefix:       prefix,
+		AuthValidator:    validator,
+	}
+	server, err := NewGateServer(cfg)
+	if err != nil {
+		t.Fatalf("NewGateServer: %v", err)
+	}
+	t.Cleanup(func() { server.Stop() })
+
+	if err := server.Start(context.Background()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	conn, err := grpc.NewClient(listenAddr, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		t.Fatalf("grpc.NewClient: %v", err)
+	}
+	t.Cleanup(func() { conn.Close() })
+
+	return server, gate_pb.NewGateServiceClient(conn)
+}
+
+// TestGateServerRegister_AuthReject verifies that Register returns Unauthenticated
+// when the AuthValidator rejects the incoming connection.
+func TestGateServerRegister_AuthReject(t *testing.T) {
+	t.Parallel()
+	_, client := authGateServer(t, "/test-gate-auth-reject",
+		&stubAuthValidator{err: errors.New("invalid token")})
+
+	stream, err := client.Register(context.Background(), &gate_pb.Empty{})
+	if err != nil {
+		t.Fatalf("Register stream: %v", err)
+	}
+
+	_, err = stream.Recv()
+	if err == nil {
+		t.Fatal("expected Unauthenticated error, got nil")
+	}
+	if code := status.Code(err); code != codes.Unauthenticated {
+		t.Fatalf("expected codes.Unauthenticated, got %v", code)
+	}
+}
+
+// TestGateServerCallObject_AuthRequired_EmptyClientID verifies that CallObject
+// returns Unauthenticated when auth is configured but ClientId is empty.
+func TestGateServerCallObject_AuthRequired_EmptyClientID(t *testing.T) {
+	t.Parallel()
+	_, client := authGateServer(t, "/test-gate-auth-callobj-empty",
+		&stubAuthValidator{identity: &callcontext.CallerIdentity{UserID: "alice"}})
+
+	_, err := client.CallObject(context.Background(), &gate_pb.CallObjectRequest{
+		ClientId: "",
+		Method:   "SomeMethod",
+		Type:     "SomeType",
+		Id:       "obj1",
+	})
+	if err == nil {
+		t.Fatal("expected Unauthenticated error, got nil")
+	}
+	if code := status.Code(err); code != codes.Unauthenticated {
+		t.Fatalf("expected codes.Unauthenticated, got %v", code)
+	}
+}
+
+// TestGateServerCallObject_AuthRequired_InvalidClientID verifies that CallObject
+// returns Unauthenticated when the ClientId does not correspond to an active
+// authenticated Register session.
+func TestGateServerCallObject_AuthRequired_InvalidClientID(t *testing.T) {
+	t.Parallel()
+	_, client := authGateServer(t, "/test-gate-auth-callobj-invalid",
+		&stubAuthValidator{identity: &callcontext.CallerIdentity{UserID: "alice"}})
+
+	_, err := client.CallObject(context.Background(), &gate_pb.CallObjectRequest{
+		ClientId: "not-a-registered-client",
+		Method:   "SomeMethod",
+		Type:     "SomeType",
+		Id:       "obj1",
+	})
+	if err == nil {
+		t.Fatal("expected Unauthenticated error, got nil")
+	}
+	if code := status.Code(err); code != codes.Unauthenticated {
+		t.Fatalf("expected codes.Unauthenticated, got %v", code)
+	}
+}

--- a/gate/gateserver/gateserver_auth_test.go
+++ b/gate/gateserver/gateserver_auth_test.go
@@ -3,7 +3,6 @@ package gateserver
 import (
 	"context"
 	"errors"
-	"io"
 	"testing"
 
 	gate_pb "github.com/xiaonanln/goverse/gate/proto"
@@ -12,9 +11,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials/insecure"
-	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
-	"google.golang.org/protobuf/proto"
 )
 
 type stubAuthValidator struct {
@@ -55,34 +52,6 @@ func authGateServer(t *testing.T, prefix string, validator callcontext.AuthValid
 	return server, gate_pb.NewGateServiceClient(conn)
 }
 
-// registerAndGetSession opens a Register stream with a valid auth token and
-// returns the clientID + sessionToken from RegisterResponse.
-func registerAndGetSession(t *testing.T, client gate_pb.GateServiceClient) (clientID, sessionToken string, cancelStream func()) {
-	t.Helper()
-	ctx, cancel := context.WithCancel(context.Background())
-	stream, err := client.Register(ctx, &gate_pb.Empty{})
-	if err != nil {
-		cancel()
-		t.Fatalf("Register: %v", err)
-	}
-
-	anyMsg, err := stream.Recv()
-	if err != nil {
-		cancel()
-		t.Fatalf("Register Recv: %v", err)
-	}
-
-	var regResp gate_pb.RegisterResponse
-	if err := proto.Unmarshal(anyMsg.Value, &regResp); err != nil {
-		// anyMsg wraps RegisterResponse — unmarshal from Any.Value directly
-		// using the typeURL to locate the message descriptor is unnecessary here;
-		// try proto.Unmarshal first (works when the Any value is the raw bytes).
-		cancel()
-		t.Fatalf("unmarshal RegisterResponse: %v", err)
-	}
-	return regResp.ClientId, regResp.SessionToken, cancel
-}
-
 // TestGateServerRegister_AuthReject verifies that Register returns Unauthenticated
 // when the AuthValidator rejects the incoming connection.
 func TestGateServerRegister_AuthReject(t *testing.T) {
@@ -101,24 +70,6 @@ func TestGateServerRegister_AuthReject(t *testing.T) {
 	}
 	if code := status.Code(err); code != codes.Unauthenticated {
 		t.Fatalf("expected codes.Unauthenticated, got %v", code)
-	}
-}
-
-// TestGateServerRegister_AuthSuccess verifies that RegisterResponse contains a
-// non-empty session_token when auth is configured and credentials are valid.
-func TestGateServerRegister_AuthSuccess(t *testing.T) {
-	t.Parallel()
-	_, client := authGateServer(t, "/test-gate-auth-success",
-		&stubAuthValidator{identity: &callcontext.CallerIdentity{UserID: "alice"}})
-
-	clientID, sessionToken, cancel := registerAndGetSession(t, client)
-	defer cancel()
-
-	if clientID == "" {
-		t.Error("expected non-empty client_id in RegisterResponse")
-	}
-	if sessionToken == "" {
-		t.Error("expected non-empty session_token in RegisterResponse when auth is configured")
 	}
 }
 
@@ -162,107 +113,5 @@ func TestGateServerCallObject_AuthRequired_InvalidClientID(t *testing.T) {
 	}
 	if code := status.Code(err); code != codes.Unauthenticated {
 		t.Fatalf("expected codes.Unauthenticated, got %v", code)
-	}
-}
-
-// TestGateServerCallObject_AuthRequired_MissingSessionToken verifies that CallObject
-// returns Unauthenticated when the session token metadata is absent.
-func TestGateServerCallObject_AuthRequired_MissingSessionToken(t *testing.T) {
-	t.Parallel()
-	_, client := authGateServer(t, "/test-gate-auth-callobj-no-token",
-		&stubAuthValidator{identity: &callcontext.CallerIdentity{UserID: "alice"}})
-
-	clientID, _, cancel := registerAndGetSession(t, client)
-	defer cancel()
-
-	// Send CallObject with correct clientID but no x-session-token metadata.
-	_, err := client.CallObject(context.Background(), &gate_pb.CallObjectRequest{
-		ClientId: clientID,
-		Method:   "SomeMethod",
-		Type:     "SomeType",
-		Id:       "obj1",
-	})
-	if err == nil {
-		t.Fatal("expected Unauthenticated error, got nil")
-	}
-	if code := status.Code(err); code != codes.Unauthenticated {
-		t.Fatalf("expected codes.Unauthenticated, got %v", code)
-	}
-}
-
-// TestGateServerCallObject_AuthRequired_WrongSessionToken verifies that CallObject
-// returns Unauthenticated when a wrong session token is presented — i.e. a caller
-// who knows the clientID cannot impersonate the owner without the correct token.
-func TestGateServerCallObject_AuthRequired_WrongSessionToken(t *testing.T) {
-	t.Parallel()
-	_, client := authGateServer(t, "/test-gate-auth-callobj-wrong-token",
-		&stubAuthValidator{identity: &callcontext.CallerIdentity{UserID: "alice"}})
-
-	clientID, _, cancel := registerAndGetSession(t, client)
-	defer cancel()
-
-	ctx := metadata.NewOutgoingContext(context.Background(),
-		metadata.Pairs("x-session-token", "not-the-right-token"))
-
-	_, err := client.CallObject(ctx, &gate_pb.CallObjectRequest{
-		ClientId: clientID,
-		Method:   "SomeMethod",
-		Type:     "SomeType",
-		Id:       "obj1",
-	})
-	if err == nil {
-		t.Fatal("expected Unauthenticated error, got nil")
-	}
-	if code := status.Code(err); code != codes.Unauthenticated {
-		t.Fatalf("expected codes.Unauthenticated, got %v", code)
-	}
-}
-
-// TestGateServerRegister_NoAuth_NoSessionToken verifies that when AuthValidator
-// is nil, RegisterResponse has an empty session_token (backward compatible).
-func TestGateServerRegister_NoAuth_NoSessionToken(t *testing.T) {
-	t.Parallel()
-	listenAddr := testutil.GetFreeAddress()
-	cfg := &GateServerConfig{
-		ListenAddress:    listenAddr,
-		AdvertiseAddress: listenAddr,
-		EtcdAddress:      "localhost:2379",
-		EtcdPrefix:       "/test-gate-noauth-token",
-	}
-	server, err := NewGateServer(cfg)
-	if err != nil {
-		t.Fatalf("NewGateServer: %v", err)
-	}
-	t.Cleanup(func() { server.Stop() })
-	if err := server.Start(context.Background()); err != nil {
-		t.Fatalf("Start: %v", err)
-	}
-
-	conn, err := grpc.NewClient(listenAddr, grpc.WithTransportCredentials(insecure.NewCredentials()))
-	if err != nil {
-		t.Fatalf("grpc.NewClient: %v", err)
-	}
-	t.Cleanup(func() { conn.Close() })
-
-	client := gate_pb.NewGateServiceClient(conn)
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	stream, err := client.Register(ctx, &gate_pb.Empty{})
-	if err != nil {
-		t.Fatalf("Register: %v", err)
-	}
-	anyMsg, err := stream.Recv()
-	if err != nil && err != io.EOF {
-		t.Fatalf("Recv: %v", err)
-	}
-	if anyMsg == nil {
-		t.Skip("no RegisterResponse received (gate not fully connected)")
-	}
-	var regResp gate_pb.RegisterResponse
-	if err := proto.Unmarshal(anyMsg.Value, &regResp); err != nil {
-		t.Fatalf("unmarshal: %v", err)
-	}
-	if regResp.SessionToken != "" {
-		t.Errorf("expected empty session_token when auth is disabled, got %q", regResp.SessionToken)
 	}
 }

--- a/gate/gateserver/gateserver_auth_test.go
+++ b/gate/gateserver/gateserver_auth_test.go
@@ -3,6 +3,7 @@ package gateserver
 import (
 	"context"
 	"errors"
+	"io"
 	"testing"
 
 	gate_pb "github.com/xiaonanln/goverse/gate/proto"
@@ -11,7 +12,9 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/proto"
 )
 
 type stubAuthValidator struct {
@@ -52,6 +55,34 @@ func authGateServer(t *testing.T, prefix string, validator callcontext.AuthValid
 	return server, gate_pb.NewGateServiceClient(conn)
 }
 
+// registerAndGetSession opens a Register stream with a valid auth token and
+// returns the clientID + sessionToken from RegisterResponse.
+func registerAndGetSession(t *testing.T, client gate_pb.GateServiceClient) (clientID, sessionToken string, cancelStream func()) {
+	t.Helper()
+	ctx, cancel := context.WithCancel(context.Background())
+	stream, err := client.Register(ctx, &gate_pb.Empty{})
+	if err != nil {
+		cancel()
+		t.Fatalf("Register: %v", err)
+	}
+
+	anyMsg, err := stream.Recv()
+	if err != nil {
+		cancel()
+		t.Fatalf("Register Recv: %v", err)
+	}
+
+	var regResp gate_pb.RegisterResponse
+	if err := proto.Unmarshal(anyMsg.Value, &regResp); err != nil {
+		// anyMsg wraps RegisterResponse — unmarshal from Any.Value directly
+		// using the typeURL to locate the message descriptor is unnecessary here;
+		// try proto.Unmarshal first (works when the Any value is the raw bytes).
+		cancel()
+		t.Fatalf("unmarshal RegisterResponse: %v", err)
+	}
+	return regResp.ClientId, regResp.SessionToken, cancel
+}
+
 // TestGateServerRegister_AuthReject verifies that Register returns Unauthenticated
 // when the AuthValidator rejects the incoming connection.
 func TestGateServerRegister_AuthReject(t *testing.T) {
@@ -70,6 +101,24 @@ func TestGateServerRegister_AuthReject(t *testing.T) {
 	}
 	if code := status.Code(err); code != codes.Unauthenticated {
 		t.Fatalf("expected codes.Unauthenticated, got %v", code)
+	}
+}
+
+// TestGateServerRegister_AuthSuccess verifies that RegisterResponse contains a
+// non-empty session_token when auth is configured and credentials are valid.
+func TestGateServerRegister_AuthSuccess(t *testing.T) {
+	t.Parallel()
+	_, client := authGateServer(t, "/test-gate-auth-success",
+		&stubAuthValidator{identity: &callcontext.CallerIdentity{UserID: "alice"}})
+
+	clientID, sessionToken, cancel := registerAndGetSession(t, client)
+	defer cancel()
+
+	if clientID == "" {
+		t.Error("expected non-empty client_id in RegisterResponse")
+	}
+	if sessionToken == "" {
+		t.Error("expected non-empty session_token in RegisterResponse when auth is configured")
 	}
 }
 
@@ -113,5 +162,107 @@ func TestGateServerCallObject_AuthRequired_InvalidClientID(t *testing.T) {
 	}
 	if code := status.Code(err); code != codes.Unauthenticated {
 		t.Fatalf("expected codes.Unauthenticated, got %v", code)
+	}
+}
+
+// TestGateServerCallObject_AuthRequired_MissingSessionToken verifies that CallObject
+// returns Unauthenticated when the session token metadata is absent.
+func TestGateServerCallObject_AuthRequired_MissingSessionToken(t *testing.T) {
+	t.Parallel()
+	_, client := authGateServer(t, "/test-gate-auth-callobj-no-token",
+		&stubAuthValidator{identity: &callcontext.CallerIdentity{UserID: "alice"}})
+
+	clientID, _, cancel := registerAndGetSession(t, client)
+	defer cancel()
+
+	// Send CallObject with correct clientID but no x-session-token metadata.
+	_, err := client.CallObject(context.Background(), &gate_pb.CallObjectRequest{
+		ClientId: clientID,
+		Method:   "SomeMethod",
+		Type:     "SomeType",
+		Id:       "obj1",
+	})
+	if err == nil {
+		t.Fatal("expected Unauthenticated error, got nil")
+	}
+	if code := status.Code(err); code != codes.Unauthenticated {
+		t.Fatalf("expected codes.Unauthenticated, got %v", code)
+	}
+}
+
+// TestGateServerCallObject_AuthRequired_WrongSessionToken verifies that CallObject
+// returns Unauthenticated when a wrong session token is presented — i.e. a caller
+// who knows the clientID cannot impersonate the owner without the correct token.
+func TestGateServerCallObject_AuthRequired_WrongSessionToken(t *testing.T) {
+	t.Parallel()
+	_, client := authGateServer(t, "/test-gate-auth-callobj-wrong-token",
+		&stubAuthValidator{identity: &callcontext.CallerIdentity{UserID: "alice"}})
+
+	clientID, _, cancel := registerAndGetSession(t, client)
+	defer cancel()
+
+	ctx := metadata.NewOutgoingContext(context.Background(),
+		metadata.Pairs("x-session-token", "not-the-right-token"))
+
+	_, err := client.CallObject(ctx, &gate_pb.CallObjectRequest{
+		ClientId: clientID,
+		Method:   "SomeMethod",
+		Type:     "SomeType",
+		Id:       "obj1",
+	})
+	if err == nil {
+		t.Fatal("expected Unauthenticated error, got nil")
+	}
+	if code := status.Code(err); code != codes.Unauthenticated {
+		t.Fatalf("expected codes.Unauthenticated, got %v", code)
+	}
+}
+
+// TestGateServerRegister_NoAuth_NoSessionToken verifies that when AuthValidator
+// is nil, RegisterResponse has an empty session_token (backward compatible).
+func TestGateServerRegister_NoAuth_NoSessionToken(t *testing.T) {
+	t.Parallel()
+	listenAddr := testutil.GetFreeAddress()
+	cfg := &GateServerConfig{
+		ListenAddress:    listenAddr,
+		AdvertiseAddress: listenAddr,
+		EtcdAddress:      "localhost:2379",
+		EtcdPrefix:       "/test-gate-noauth-token",
+	}
+	server, err := NewGateServer(cfg)
+	if err != nil {
+		t.Fatalf("NewGateServer: %v", err)
+	}
+	t.Cleanup(func() { server.Stop() })
+	if err := server.Start(context.Background()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	conn, err := grpc.NewClient(listenAddr, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		t.Fatalf("grpc.NewClient: %v", err)
+	}
+	t.Cleanup(func() { conn.Close() })
+
+	client := gate_pb.NewGateServiceClient(conn)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	stream, err := client.Register(ctx, &gate_pb.Empty{})
+	if err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+	anyMsg, err := stream.Recv()
+	if err != nil && err != io.EOF {
+		t.Fatalf("Recv: %v", err)
+	}
+	if anyMsg == nil {
+		t.Skip("no RegisterResponse received (gate not fully connected)")
+	}
+	var regResp gate_pb.RegisterResponse
+	if err := proto.Unmarshal(anyMsg.Value, &regResp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if regResp.SessionToken != "" {
+		t.Errorf("expected empty session_token when auth is disabled, got %q", regResp.SessionToken)
 	}
 }

--- a/gate/proto/gate.proto
+++ b/gate/proto/gate.proto
@@ -14,13 +14,9 @@ service GateService {
     rpc ReliableCallObject (ReliableCallObjectRequest) returns (ReliableCallObjectResponse);
 }
 
-// RegisterResponse is the first message that the client can receive from the Register stream.
-// When AuthValidator is configured, session_token is a cryptographically random token that
-// the client must include as the "x-session-token" gRPC metadata key on every CallObject
-// request. This proves the caller owns the Register session and prevents impersonation.
+// RegisterResponse is the first message that the client can receive from the Register stream
 message RegisterResponse {
   string client_id = 1;
-  string session_token = 2; // Non-empty only when AuthValidator is configured.
 }
 
 message CallObjectRequest {

--- a/gate/proto/gate.proto
+++ b/gate/proto/gate.proto
@@ -14,9 +14,13 @@ service GateService {
     rpc ReliableCallObject (ReliableCallObjectRequest) returns (ReliableCallObjectResponse);
 }
 
-// RegisterResponse is the first message that the client can receive from the Register stream
+// RegisterResponse is the first message that the client can receive from the Register stream.
+// When AuthValidator is configured, session_token is a cryptographically random token that
+// the client must include as the "x-session-token" gRPC metadata key on every CallObject
+// request. This proves the caller owns the Register session and prevents impersonation.
 message RegisterResponse {
   string client_id = 1;
+  string session_token = 2; // Non-empty only when AuthValidator is configured.
 }
 
 message CallObjectRequest {

--- a/goverseapi/auth.go
+++ b/goverseapi/auth.go
@@ -55,24 +55,6 @@ server side.
 The metadata is sent as HTTP/2 headers when the stream is opened and is
 available to Validate immediately, before any messages are exchanged.
 
-After Register succeeds, the gate returns a RegisterResponse containing both
-the client_id and a cryptographically random session_token. The client must
-echo the session token back as the "x-session-token" metadata key on every
-subsequent CallObject request. This binds each unary call to the Register
-session and prevents impersonation: knowing another client's ID is not
-sufficient without also holding its session token.
-
-	anyMsg, _ := stream.Recv()
-	// unmarshal anyMsg to gate_pb.RegisterResponse to get ClientId + SessionToken
-
-	callCtx := metadata.NewOutgoingContext(context.Background(),
-	    metadata.Pairs("x-session-token", sessionToken))
-
-	resp, err := gateClient.CallObject(callCtx, &gate_pb.CallObjectRequest{
-	    ClientId: clientID,
-	    // ...
-	})
-
 ## Reading the caller identity inside object methods
 
 Once auth is configured, every object method receives the validated identity

--- a/goverseapi/auth.go
+++ b/goverseapi/auth.go
@@ -1,3 +1,80 @@
+/*
+Package goverseapi provides the public API for Goverse object methods and gate
+configuration.
+
+# Authentication and Caller Identity
+
+Goverse gates support pluggable authentication via the [AuthValidator] interface.
+When wired in, every client connection is authenticated during Register and the
+resulting [CallerIdentity] is automatically injected into the context of every
+subsequent [CallObject] call — no boilerplate needed in individual object methods.
+
+## Server side: implementing and wiring AuthValidator
+
+Implement [AuthValidator] with whatever token-validation logic your app needs,
+then pass it to [gateserver.GateServerConfig]:
+
+	type myAuth struct{ secret []byte }
+
+	func (a *myAuth) Validate(ctx context.Context, headers map[string][]string) (*goverseapi.CallerIdentity, error) {
+	    vals := headers["authorization"] // gRPC metadata key (lowercase)
+	    if len(vals) == 0 {
+	        return nil, fmt.Errorf("missing authorization header")
+	    }
+	    token := strings.TrimPrefix(vals[0], "Bearer ")
+	    userID, roles, err := verifyJWT(token, a.secret)
+	    if err != nil {
+	        return nil, err // causes codes.Unauthenticated on the client
+	    }
+	    return &goverseapi.CallerIdentity{UserID: userID, Roles: roles}, nil
+	}
+
+	// Wire at startup:
+	cfg := &gateserver.GateServerConfig{
+	    ListenAddress: ":7001",
+	    AuthValidator: &myAuth{secret: jwtSecret},
+	    // ...
+	}
+
+When AuthValidator is nil (the default) the gate behaves exactly as in v0.1:
+all connections are accepted and CallerUserID(ctx) returns "".
+
+## Client side: sending the authorization token
+
+The client attaches credentials as gRPC metadata before opening the Register
+stream. The gate reads the metadata via metadata.FromIncomingContext on the
+server side.
+
+	import "google.golang.org/grpc/metadata"
+
+	md := metadata.Pairs("authorization", "Bearer "+myToken)
+	ctx := metadata.NewOutgoingContext(context.Background(), md)
+
+	stream, err := gateClient.Register(ctx, &gate_pb.Empty{})
+
+The metadata is sent as HTTP/2 headers when the stream is opened and is
+available to Validate immediately, before any messages are exchanged.
+
+## Reading the caller identity inside object methods
+
+Once auth is configured, every object method receives the validated identity
+through its context automatically:
+
+	func (m *Match) HandleInput(ctx context.Context, req *pb.PlayerInputRequest) (*pb.PlayerInputResponse, error) {
+	    callerID := goverseapi.CallerUserID(ctx)
+	    if callerID == "" || callerID != req.PlayerId {
+	        return nil, status.Errorf(codes.PermissionDenied, "not your player")
+	    }
+	    // ...
+	}
+
+	func (r *Room) AdminAction(ctx context.Context, req *pb.AdminRequest) (*pb.AdminResponse, error) {
+	    if !goverseapi.CallerHasRole(ctx, "admin") {
+	        return nil, status.Errorf(codes.PermissionDenied, "admin role required")
+	    }
+	    // ...
+	}
+*/
 package goverseapi
 
 import (
@@ -7,21 +84,33 @@ import (
 )
 
 // CallerIdentity is the authenticated identity of a connected client.
+// It is populated by the gate after a successful [AuthValidator.Validate] call
+// and injected into the context of every CallObject RPC.
+//
+// UserID is a stable, opaque per-user identifier (e.g. the JWT "sub" claim).
+// Roles is an optional, application-defined list of role strings used for
+// coarse-grained access control via [CallerHasRole].
 type CallerIdentity = callcontext.CallerIdentity
 
-// AuthValidator validates client credentials on Register.
-// Implement this interface and pass it to GateServerConfig.AuthValidator.
+// AuthValidator validates client credentials when a client calls Register.
+// Implement this interface and set it on GateServerConfig.AuthValidator.
 //
-// headers contains gRPC metadata keys/values. Typically you'll read
-// headers["authorization"] for a bearer token.
+// headers contains the gRPC metadata sent by the client (lowercase keys).
+// The conventional key for bearer-token auth is "authorization", which the
+// client populates with "Bearer <token>" via metadata.NewOutgoingContext.
 //
-// Return a non-nil *CallerIdentity on success, or an error to reject the
-// connection with codes.Unauthenticated.
+// Return a non-nil *CallerIdentity on success. Return an error to reject the
+// connection; the client receives codes.Unauthenticated with the error text.
+//
+// When AuthValidator is nil, all connections are accepted and
+// CallerUserID(ctx) returns "" (v0.1 behaviour, fully backwards compatible).
 type AuthValidator = callcontext.AuthValidator
 
 // CallerUserID returns the authenticated UserID from the call context.
-// Returns empty string if the call was not authenticated (no AuthValidator
-// configured, or call originated from a node rather than a client).
+//
+// Returns "" if:
+//   - No AuthValidator is configured on the gate.
+//   - The call originated from a node rather than a client.
 func CallerUserID(ctx context.Context) string {
 	if id := callcontext.GetCallerIdentity(ctx); id != nil {
 		return id.UserID
@@ -30,7 +119,7 @@ func CallerUserID(ctx context.Context) string {
 }
 
 // CallerRoles returns the authenticated roles from the call context.
-// Returns nil if the call was not authenticated.
+// Returns nil if the call is unauthenticated.
 func CallerRoles(ctx context.Context) []string {
 	if id := callcontext.GetCallerIdentity(ctx); id != nil {
 		return id.Roles

--- a/goverseapi/auth.go
+++ b/goverseapi/auth.go
@@ -1,0 +1,39 @@
+package goverseapi
+
+import (
+	"context"
+
+	"github.com/xiaonanln/goverse/util/callcontext"
+)
+
+// CallerIdentity is the authenticated identity of a connected client.
+type CallerIdentity = callcontext.CallerIdentity
+
+// AuthValidator validates client credentials on Register.
+// Implement this interface and pass it to GateServerConfig.AuthValidator.
+//
+// headers contains gRPC metadata keys/values. Typically you'll read
+// headers["authorization"] for a bearer token.
+//
+// Return a non-nil *CallerIdentity on success, or an error to reject the
+// connection with codes.Unauthenticated.
+type AuthValidator = callcontext.AuthValidator
+
+// CallerUserID returns the authenticated UserID from the call context.
+// Returns empty string if the call was not authenticated (no AuthValidator
+// configured, or call originated from a node rather than a client).
+func CallerUserID(ctx context.Context) string {
+	if id := callcontext.GetCallerIdentity(ctx); id != nil {
+		return id.UserID
+	}
+	return ""
+}
+
+// CallerRoles returns the authenticated roles from the call context.
+// Returns nil if the call was not authenticated.
+func CallerRoles(ctx context.Context) []string {
+	if id := callcontext.GetCallerIdentity(ctx); id != nil {
+		return id.Roles
+	}
+	return nil
+}

--- a/goverseapi/auth.go
+++ b/goverseapi/auth.go
@@ -55,6 +55,24 @@ server side.
 The metadata is sent as HTTP/2 headers when the stream is opened and is
 available to Validate immediately, before any messages are exchanged.
 
+After Register succeeds, the gate returns a RegisterResponse containing both
+the client_id and a cryptographically random session_token. The client must
+echo the session token back as the "x-session-token" metadata key on every
+subsequent CallObject request. This binds each unary call to the Register
+session and prevents impersonation: knowing another client's ID is not
+sufficient without also holding its session token.
+
+	anyMsg, _ := stream.Recv()
+	// unmarshal anyMsg to gate_pb.RegisterResponse to get ClientId + SessionToken
+
+	callCtx := metadata.NewOutgoingContext(context.Background(),
+	    metadata.Pairs("x-session-token", sessionToken))
+
+	resp, err := gateClient.CallObject(callCtx, &gate_pb.CallObjectRequest{
+	    ClientId: clientID,
+	    // ...
+	})
+
 ## Reading the caller identity inside object methods
 
 Once auth is configured, every object method receives the validated identity

--- a/goverseapi/auth.go
+++ b/goverseapi/auth.go
@@ -37,3 +37,18 @@ func CallerRoles(ctx context.Context) []string {
 	}
 	return nil
 }
+
+// CallerHasRole reports whether the authenticated caller holds the given role.
+// Returns false if the call is unauthenticated or the role is not present.
+func CallerHasRole(ctx context.Context, role string) bool {
+	id := callcontext.GetCallerIdentity(ctx)
+	if id == nil {
+		return false
+	}
+	for _, r := range id.Roles {
+		if r == role {
+			return true
+		}
+	}
+	return false
+}

--- a/goverseapi/auth_test.go
+++ b/goverseapi/auth_test.go
@@ -1,0 +1,72 @@
+package goverseapi
+
+import (
+	"context"
+	"testing"
+
+	"github.com/xiaonanln/goverse/util/callcontext"
+)
+
+func ctxWithIdentity(userID string, roles []string) context.Context {
+	return callcontext.WithCallerIdentity(context.Background(), &callcontext.CallerIdentity{
+		UserID: userID,
+		Roles:  roles,
+	})
+}
+
+func TestCallerUserID(t *testing.T) {
+	ctx := ctxWithIdentity("alice", nil)
+	if got := CallerUserID(ctx); got != "alice" {
+		t.Errorf("got %q, want %q", got, "alice")
+	}
+}
+
+func TestCallerUserID_Unauthenticated(t *testing.T) {
+	if got := CallerUserID(context.Background()); got != "" {
+		t.Errorf("expected empty string for unauthenticated context, got %q", got)
+	}
+}
+
+func TestCallerRoles(t *testing.T) {
+	ctx := ctxWithIdentity("alice", []string{"admin", "editor"})
+	roles := CallerRoles(ctx)
+	if len(roles) != 2 || roles[0] != "admin" || roles[1] != "editor" {
+		t.Errorf("unexpected roles: %v", roles)
+	}
+}
+
+func TestCallerRoles_Unauthenticated(t *testing.T) {
+	if got := CallerRoles(context.Background()); got != nil {
+		t.Errorf("expected nil roles for unauthenticated context, got %v", got)
+	}
+}
+
+func TestCallerHasRole_Match(t *testing.T) {
+	ctx := ctxWithIdentity("alice", []string{"admin", "editor"})
+	if !CallerHasRole(ctx, "admin") {
+		t.Error("expected CallerHasRole to return true for 'admin'")
+	}
+	if !CallerHasRole(ctx, "editor") {
+		t.Error("expected CallerHasRole to return true for 'editor'")
+	}
+}
+
+func TestCallerHasRole_NoMatch(t *testing.T) {
+	ctx := ctxWithIdentity("alice", []string{"editor"})
+	if CallerHasRole(ctx, "admin") {
+		t.Error("expected CallerHasRole to return false for 'admin'")
+	}
+}
+
+func TestCallerHasRole_Unauthenticated(t *testing.T) {
+	if CallerHasRole(context.Background(), "admin") {
+		t.Error("expected CallerHasRole to return false for unauthenticated context")
+	}
+}
+
+func TestCallerHasRole_EmptyRoles(t *testing.T) {
+	ctx := ctxWithIdentity("alice", []string{})
+	if CallerHasRole(ctx, "admin") {
+		t.Error("expected CallerHasRole to return false when roles list is empty")
+	}
+}

--- a/util/callcontext/callcontext.go
+++ b/util/callcontext/callcontext.go
@@ -9,9 +9,37 @@ import (
 type contextKey int
 
 const (
-	// clientIDKey is the context key for storing the client ID
-	clientIDKey contextKey = iota
+	clientIDKey       contextKey = iota
+	callerIdentityKey contextKey = iota
 )
+
+// CallerIdentity holds the authenticated identity of a client connection.
+// Populated by the gate after a successful AuthValidator.Validate call.
+type CallerIdentity struct {
+	UserID string
+	Roles  []string
+}
+
+// AuthValidator validates client credentials during Register.
+// headers contains gRPC metadata (or HTTP headers) from the incoming request.
+// Return a non-nil CallerIdentity on success, or an error to reject the connection.
+type AuthValidator interface {
+	Validate(ctx context.Context, headers map[string][]string) (*CallerIdentity, error)
+}
+
+// WithCallerIdentity returns a new context with the CallerIdentity stored.
+func WithCallerIdentity(ctx context.Context, id *CallerIdentity) context.Context {
+	return context.WithValue(ctx, callerIdentityKey, id)
+}
+
+// GetCallerIdentity retrieves the CallerIdentity from the context.
+// Returns nil if no identity is present.
+func GetCallerIdentity(ctx context.Context) *CallerIdentity {
+	if id, ok := ctx.Value(callerIdentityKey).(*CallerIdentity); ok {
+		return id
+	}
+	return nil
+}
 
 // WithClientID returns a new context with the client ID stored
 // clientID format: "gateAddress/uniqueId" (e.g., "localhost:7001/abc123")

--- a/util/callcontext/callcontext_test.go
+++ b/util/callcontext/callcontext_test.go
@@ -90,6 +90,62 @@ func TestContextChaining(t *testing.T) {
 	}
 }
 
+func TestWithCallerIdentity(t *testing.T) {
+	ctx := context.Background()
+	id := &CallerIdentity{UserID: "user1", Roles: []string{"admin", "viewer"}}
+
+	ctx = WithCallerIdentity(ctx, id)
+
+	got := GetCallerIdentity(ctx)
+	if got == nil {
+		t.Fatal("Expected CallerIdentity, got nil")
+	}
+	if got.UserID != id.UserID {
+		t.Errorf("Expected UserID %q, got %q", id.UserID, got.UserID)
+	}
+	if len(got.Roles) != len(id.Roles) || got.Roles[0] != id.Roles[0] {
+		t.Errorf("Expected Roles %v, got %v", id.Roles, got.Roles)
+	}
+}
+
+func TestGetCallerIdentity_NotPresent(t *testing.T) {
+	ctx := context.Background()
+	if got := GetCallerIdentity(ctx); got != nil {
+		t.Errorf("Expected nil CallerIdentity, got %+v", got)
+	}
+}
+
+func TestWithCallerIdentity_NilIdentity(t *testing.T) {
+	ctx := WithCallerIdentity(context.Background(), nil)
+	if got := GetCallerIdentity(ctx); got != nil {
+		t.Errorf("Expected nil after storing nil identity, got %+v", got)
+	}
+}
+
+func TestCallerIdentity_IsolatedFromOtherContexts(t *testing.T) {
+	id := &CallerIdentity{UserID: "user1"}
+	ctx1 := WithCallerIdentity(context.Background(), id)
+	ctx2 := context.Background()
+
+	if GetCallerIdentity(ctx2) != nil {
+		t.Error("Expected ctx2 to have no CallerIdentity")
+	}
+	if GetCallerIdentity(ctx1) == nil {
+		t.Error("Expected ctx1 to have CallerIdentity")
+	}
+}
+
+func TestCallerIdentity_PreservedInDerivedContext(t *testing.T) {
+	id := &CallerIdentity{UserID: "user1", Roles: []string{"editor"}}
+	ctx := WithCallerIdentity(context.Background(), id)
+	derived := context.WithValue(ctx, "other-key", "other-value")
+
+	got := GetCallerIdentity(derived)
+	if got == nil || got.UserID != "user1" {
+		t.Errorf("Expected CallerIdentity to be preserved in derived context, got %+v", got)
+	}
+}
+
 func TestWithDefaultTimeout_NoExistingDeadline(t *testing.T) {
 	ctx := context.Background()
 	defaultTimeout := 5 * time.Second


### PR DESCRIPTION
## Summary

Implements auth middleware described in `docs/design/V0_2_TRUST_BOUNDARY.md` §4 (Item 2).

- **`util/callcontext`**: add `CallerIdentity` struct, `AuthValidator` interface, `WithCallerIdentity`/`GetCallerIdentity` context helpers
- **`goverseapi/auth.go`** (new): re-export `CallerIdentity` and `AuthValidator` as type aliases; add `CallerUserID(ctx)` and `CallerRoles(ctx)` helpers for use inside object methods
- **`gate/gateserver`**: add `AuthValidator` to `GateServerConfig`; validate gRPC metadata on `Register()`, store `clientID → identity` in `sync.Map`, inject identity into context on every `CallObject()`

When `AuthValidator == nil` (default), behaviour is identical to v0.1 — fully backwards compatible.

## Usage

```go
// Implement the interface with any token logic
type myAuth struct{}
func (a *myAuth) Validate(ctx context.Context, headers map[string][]string) (*goverseapi.CallerIdentity, error) {
    userID, err := lookupToken(headers["authorization"][0])
    if err != nil {
        return nil, err
    }
    return &goverseapi.CallerIdentity{UserID: userID}, nil
}

// Wire it in at startup
cfg := &gateserver.GateServerConfig{
    AuthValidator: &myAuth{},
}

// Read identity inside object methods
func (r *ChatRoom) Join(ctx context.Context, req *pb.JoinRequest) (...) {
    userID := goverseapi.CallerUserID(ctx)
}
```

## Test plan

- [x] `go build ./...` — clean
- [x] All existing tests pass (`gate/gateserver`, `goverseapi`, `util/callcontext` all green)
- [ ] `util/postgres` integration failures are pre-existing (no local Postgres credentials) — unrelated

🤖 Generated with [Claude Code](https://claude.com/claude-code)