### PR TITLE
feat(callcontext): propagate full CallerIdentity (UserID + Roles) across node boundaries

### DIFF
--- a/util/callcontext/callcontext.go
+++ b/util/callcontext/callcontext.go
@@ -7,9 +7,12 @@ import (
 	"google.golang.org/grpc/metadata"
 )
 
-// mdKeyCallerUserID is the gRPC metadata key used to propagate the caller's
-// user ID across node boundaries. Owned here so no other package needs it.
-const mdKeyCallerUserID = "x-caller-user-id"
+// Metadata keys used to propagate CallerIdentity across gRPC node boundaries.
+// Owned entirely by this package — no other package should reference these strings.
+const (
+	mdKeyCallerUserID = "x-caller-user-id"
+	mdKeyCallerRoles  = "x-caller-roles" // repeated: one value per role
+)
 
 // contextKey is a private type for context keys to avoid collisions
 type contextKey int
@@ -76,26 +79,39 @@ func FromClient(ctx context.Context) bool {
 	return ctx.Value(clientIDKey) != nil
 }
 
-// InjectCallerToOutgoing appends the caller's UserID from ctx as gRPC outgoing
-// metadata so the receiving node can restore it via ExtractCallerFromIncoming.
-// If no CallerIdentity is present, ctx is returned unchanged.
+// InjectCallerToOutgoing appends the full CallerIdentity (UserID + Roles) from
+// ctx as gRPC outgoing metadata so the receiving node can restore it via
+// ExtractCallerFromIncoming. If no CallerIdentity is present, ctx is returned
+// unchanged.
 func InjectCallerToOutgoing(ctx context.Context) context.Context {
-	if userID := CallerUserID(ctx); userID != "" {
-		return metadata.AppendToOutgoingContext(ctx, mdKeyCallerUserID, userID)
+	id := GetCallerIdentity(ctx)
+	if id == nil || id.UserID == "" {
+		return ctx
 	}
-	return ctx
+	pairs := []string{mdKeyCallerUserID, id.UserID}
+	for _, role := range id.Roles {
+		pairs = append(pairs, mdKeyCallerRoles, role)
+	}
+	return metadata.AppendToOutgoingContext(ctx, pairs...)
 }
 
-// ExtractCallerFromIncoming reads the caller's UserID from gRPC incoming
-// metadata and injects it as a CallerIdentity into the returned context.
-// If the metadata key is absent or empty, ctx is returned unchanged.
+// ExtractCallerFromIncoming reads the full CallerIdentity (UserID + Roles) from
+// gRPC incoming metadata and injects it into the returned context.
+// If the user-ID key is absent or empty, ctx is returned unchanged.
 func ExtractCallerFromIncoming(ctx context.Context) context.Context {
-	if md, ok := metadata.FromIncomingContext(ctx); ok {
-		if vals := md[mdKeyCallerUserID]; len(vals) > 0 && vals[0] != "" {
-			ctx = WithCallerIdentity(ctx, &CallerIdentity{UserID: vals[0]})
-		}
+	md, ok := metadata.FromIncomingContext(ctx)
+	if !ok {
+		return ctx
 	}
-	return ctx
+	userIDVals := md[mdKeyCallerUserID]
+	if len(userIDVals) == 0 || userIDVals[0] == "" {
+		return ctx
+	}
+	id := &CallerIdentity{
+		UserID: userIDVals[0],
+		Roles:  md[mdKeyCallerRoles], // nil if key absent — that's fine
+	}
+	return WithCallerIdentity(ctx, id)
 }
 
 // WithDefaultTimeout returns a context with the specified timeout applied only if

--- a/util/callcontext/callcontext_test.go
+++ b/util/callcontext/callcontext_test.go
@@ -219,7 +219,7 @@ func TestWithDefaultTimeout_CancelNoopWhenDeadlineExists(t *testing.T) {
 	cancel() // Call multiple times to ensure it's safe
 }
 
-func TestInjectCallerToOutgoing_WithIdentity(t *testing.T) {
+func TestInjectCallerToOutgoing_UserIDOnly(t *testing.T) {
 	ctx := WithCallerIdentity(context.Background(), &CallerIdentity{UserID: "alice"})
 	out := InjectCallerToOutgoing(ctx)
 
@@ -227,9 +227,31 @@ func TestInjectCallerToOutgoing_WithIdentity(t *testing.T) {
 	if !ok {
 		t.Fatal("Expected outgoing metadata to be set")
 	}
-	vals := md[mdKeyCallerUserID]
-	if len(vals) == 0 || vals[0] != "alice" {
-		t.Errorf("Expected metadata %q = %q, got %v", mdKeyCallerUserID, "alice", vals)
+	if vals := md[mdKeyCallerUserID]; len(vals) == 0 || vals[0] != "alice" {
+		t.Errorf("Expected %q = %q, got %v", mdKeyCallerUserID, "alice", vals)
+	}
+	if vals := md[mdKeyCallerRoles]; len(vals) != 0 {
+		t.Errorf("Expected no roles metadata, got %v", vals)
+	}
+}
+
+func TestInjectCallerToOutgoing_WithRoles(t *testing.T) {
+	ctx := WithCallerIdentity(context.Background(), &CallerIdentity{
+		UserID: "alice",
+		Roles:  []string{"admin", "viewer"},
+	})
+	out := InjectCallerToOutgoing(ctx)
+
+	md, ok := metadata.FromOutgoingContext(out)
+	if !ok {
+		t.Fatal("Expected outgoing metadata to be set")
+	}
+	if vals := md[mdKeyCallerUserID]; len(vals) == 0 || vals[0] != "alice" {
+		t.Errorf("Expected %q = %q, got %v", mdKeyCallerUserID, "alice", vals)
+	}
+	roles := md[mdKeyCallerRoles]
+	if len(roles) != 2 || roles[0] != "admin" || roles[1] != "viewer" {
+		t.Errorf("Expected roles [admin viewer], got %v", roles)
 	}
 }
 
@@ -237,16 +259,14 @@ func TestInjectCallerToOutgoing_NoIdentity(t *testing.T) {
 	ctx := context.Background()
 	out := InjectCallerToOutgoing(ctx)
 
-	_, ok := metadata.FromOutgoingContext(out)
-	if ok {
-		md, _ := metadata.FromOutgoingContext(out)
+	if md, ok := metadata.FromOutgoingContext(out); ok {
 		if vals := md[mdKeyCallerUserID]; len(vals) > 0 {
 			t.Errorf("Expected no %q metadata, got %v", mdKeyCallerUserID, vals)
 		}
 	}
 }
 
-func TestExtractCallerFromIncoming_WithMetadata(t *testing.T) {
+func TestExtractCallerFromIncoming_UserIDOnly(t *testing.T) {
 	md := metadata.Pairs(mdKeyCallerUserID, "bob")
 	ctx := metadata.NewIncomingContext(context.Background(), md)
 
@@ -258,6 +278,31 @@ func TestExtractCallerFromIncoming_WithMetadata(t *testing.T) {
 	}
 	if id.UserID != "bob" {
 		t.Errorf("Expected UserID %q, got %q", "bob", id.UserID)
+	}
+	if len(id.Roles) != 0 {
+		t.Errorf("Expected no roles, got %v", id.Roles)
+	}
+}
+
+func TestExtractCallerFromIncoming_WithRoles(t *testing.T) {
+	md := metadata.Pairs(
+		mdKeyCallerUserID, "carol",
+		mdKeyCallerRoles, "editor",
+		mdKeyCallerRoles, "viewer",
+	)
+	ctx := metadata.NewIncomingContext(context.Background(), md)
+
+	out := ExtractCallerFromIncoming(ctx)
+
+	id := GetCallerIdentity(out)
+	if id == nil {
+		t.Fatal("Expected CallerIdentity to be set")
+	}
+	if id.UserID != "carol" {
+		t.Errorf("Expected UserID %q, got %q", "carol", id.UserID)
+	}
+	if len(id.Roles) != 2 || id.Roles[0] != "editor" || id.Roles[1] != "viewer" {
+		t.Errorf("Expected roles [editor viewer], got %v", id.Roles)
 	}
 }
 
@@ -278,5 +323,32 @@ func TestExtractCallerFromIncoming_EmptyUserID(t *testing.T) {
 
 	if id := GetCallerIdentity(out); id != nil {
 		t.Errorf("Expected no CallerIdentity for empty user ID, got %+v", id)
+	}
+}
+
+func TestInjectExtract_RoundTrip(t *testing.T) {
+	// Simulate the full gate→node propagation: inject on outgoing, extract on incoming.
+	// gRPC doesn't let us directly convert outgoing→incoming MD in a unit test,
+	// so we build the incoming context manually from the same pairs.
+	original := &CallerIdentity{UserID: "dave", Roles: []string{"admin", "editor"}}
+	outCtx := InjectCallerToOutgoing(WithCallerIdentity(context.Background(), original))
+
+	outMD, _ := metadata.FromOutgoingContext(outCtx)
+	inCtx := metadata.NewIncomingContext(context.Background(), outMD)
+	restored := GetCallerIdentity(ExtractCallerFromIncoming(inCtx))
+
+	if restored == nil {
+		t.Fatal("Expected CallerIdentity after round-trip, got nil")
+	}
+	if restored.UserID != original.UserID {
+		t.Errorf("UserID: want %q, got %q", original.UserID, restored.UserID)
+	}
+	if len(restored.Roles) != len(original.Roles) {
+		t.Fatalf("Roles len: want %d, got %d", len(original.Roles), len(restored.Roles))
+	}
+	for i, r := range original.Roles {
+		if restored.Roles[i] != r {
+			t.Errorf("Role[%d]: want %q, got %q", i, r, restored.Roles[i])
+		}
 	}
 }


### PR DESCRIPTION
## Summary

- `InjectCallerToOutgoing` now serialises both `UserID` and `Roles` into gRPC outgoing metadata (`x-caller-user-id` + `x-caller-roles` as repeated values)
- `ExtractCallerFromIncoming` restores the full struct including roles
- Previously `CallerHasRole` would always return false on non-gate nodes because `Roles` was dropped at the first gRPC boundary

## Test plan

- `TestInjectCallerToOutgoing_UserIDOnly` — no roles emitted when Roles is empty
- `TestInjectCallerToOutgoing_WithRoles` — all roles present in outgoing metadata
- `TestInjectCallerToOutgoing_NoIdentity` — no metadata set when no identity in context
- `TestExtractCallerFromIncoming_UserIDOnly` — UserID restored, Roles empty
- `TestExtractCallerFromIncoming_WithRoles` — UserID + Roles both restored
- `TestExtractCallerFromIncoming_NoMetadata` / `_EmptyUserID` — no identity injected
- `TestInjectExtract_RoundTrip` — end-to-end: inject→extract preserves full identity

🤖 Generated with [Claude Code](https://claude.com/claude-code)