### PR TITLE
feat(auth): authjwt/authnone packages + fix ReliableCallObject identity propagation

### DIFF
--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -943,6 +943,9 @@ func (c *Cluster) ReliableCallObjectAnyRequest(ctx context.Context, callID strin
 		return nil, goverse_pb.ReliableCallStatus_SKIPPED, fmt.Errorf("failed to get connection to node %s: %w", targetNodeAddr, err)
 	}
 
+	// Propagate CallerIdentity to the receiving node as gRPC metadata.
+	ctx = callcontext.InjectCallerToOutgoing(ctx)
+
 	// Issue ReliableCallObject RPC to target node with full call data
 	req := &goverse_pb.ReliableCallObjectRequest{
 		CallId:     callID,

--- a/gate/gateserver/gate_auth_integration_test.go
+++ b/gate/gateserver/gate_auth_integration_test.go
@@ -1,0 +1,288 @@
+package gateserver
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+	gate_pb "github.com/xiaonanln/goverse/gate/proto"
+	"github.com/xiaonanln/goverse/goverseapi/authjwt"
+	"github.com/xiaonanln/goverse/util/protohelper"
+	"github.com/xiaonanln/goverse/util/testutil"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/structpb"
+)
+
+var jwtTestKey = []byte("gate-auth-integration-test-secret")
+
+func makeToken(key []byte, sub string, roles []string, expiry time.Time) string {
+	claims := jwt.MapClaims{
+		"sub": sub,
+		"exp": expiry.Unix(),
+	}
+	if len(roles) > 0 {
+		claims["roles"] = roles
+	}
+	tok, _ := jwt.NewWithClaims(jwt.SigningMethodHS256, claims).SignedString(key)
+	return tok
+}
+
+// TestGateAuth_ValidJWT verifies the end-to-end JWT path:
+//  1. Gate is wired with authjwt.New(HS256 key).
+//  2. Client sends Authorization: Bearer <valid-token> on Register.
+//  3. CallerIdentity (sub + roles) flows through the gate → node → object method.
+func TestGateAuth_ValidJWT(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.Skip("Skipping long-running integration test in short mode")
+	}
+
+	ctx := context.Background()
+	etcdPrefix := testutil.PrepareEtcdPrefix(t, "localhost:2379")
+
+	// --- Node side ---
+	nodeAddr := testutil.GetFreeAddress()
+	nodeCluster := mustNewCluster(ctx, t, nodeAddr, etcdPrefix)
+	testNode := nodeCluster.GetThisNode()
+	testNode.RegisterObjectType((*callerCapture)(nil))
+
+	mockNodeServer := testutil.NewMockGoverseServer()
+	mockNodeServer.SetNode(testNode)
+	mockNodeServer.SetCluster(nodeCluster)
+	nodeHelper := testutil.NewTestServerHelper(nodeAddr, mockNodeServer)
+	if err := nodeHelper.Start(ctx); err != nil {
+		t.Fatalf("node mock server Start: %v", err)
+	}
+	t.Cleanup(func() { nodeHelper.Stop() })
+
+	// --- Gate wired with JWT validator ---
+	gateAddr := testutil.GetFreeAddress()
+	gateServer, err := NewGateServer(&GateServerConfig{
+		ListenAddress:    gateAddr,
+		AdvertiseAddress: gateAddr,
+		EtcdAddress:      "localhost:2379",
+		EtcdPrefix:       etcdPrefix,
+		NumShards:        testutil.TestNumShards,
+		AuthValidator:    authjwt.New(authjwt.Options{SigningKey: jwtTestKey}),
+	})
+	if err != nil {
+		t.Skipf("etcd not available: %v", err)
+	}
+	t.Cleanup(func() { gateServer.Stop() })
+	if err := gateServer.Start(ctx); err != nil {
+		t.Fatalf("gateServer.Start: %v", err)
+	}
+
+	testutil.WaitForClusterReady(t, nodeCluster)
+
+	conn, err := grpc.NewClient(gateAddr, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		t.Fatalf("grpc.NewClient: %v", err)
+	}
+	t.Cleanup(func() { conn.Close() })
+	gateClient := gate_pb.NewGateServiceClient(conn)
+
+	// --- Register with a valid JWT ---
+	token := makeToken(jwtTestKey, "alice", []string{"admin", "viewer"}, time.Now().Add(time.Hour))
+	regMD := metadata.Pairs("authorization", "Bearer "+token)
+	regCtx := metadata.NewOutgoingContext(ctx, regMD)
+	stream, err := gateClient.Register(regCtx, &gate_pb.Empty{})
+	if err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+	firstMsg, err := stream.Recv()
+	if err != nil {
+		t.Fatalf("Register Recv: %v", err)
+	}
+	regResp := &gate_pb.RegisterResponse{}
+	if err := firstMsg.UnmarshalTo(regResp); err != nil {
+		t.Fatalf("UnmarshalTo RegisterResponse: %v", err)
+	}
+	clientID := regResp.ClientId
+
+	go func() {
+		for {
+			if _, err := stream.Recv(); err != nil {
+				return
+			}
+		}
+	}()
+
+	// --- Create and call object ---
+	objID := "gate-auth-jwt-integration-1"
+	createDeadline := time.Now().Add(30 * time.Second)
+	for {
+		_, err = gateClient.CreateObject(ctx, &gate_pb.CreateObjectRequest{
+			Type: "callerCapture",
+			Id:   objID,
+		})
+		if err == nil {
+			break
+		}
+		if time.Now().After(createDeadline) {
+			t.Fatalf("CreateObject still failing after 30s: %v", err)
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+	waitForObjectCreatedOnNode(t, testNode, objID, 10*time.Second)
+
+	reqAny, err := protohelper.MsgToAny(&structpb.Struct{})
+	if err != nil {
+		t.Fatalf("protohelper.MsgToAny: %v", err)
+	}
+
+	var callResp *gate_pb.CallObjectResponse
+	deadline := time.Now().Add(30 * time.Second)
+	for {
+		callResp, err = gateClient.CallObject(ctx, &gate_pb.CallObjectRequest{
+			ClientId: clientID,
+			Type:     "callerCapture",
+			Id:       objID,
+			Method:   "Capture",
+			Request:  reqAny,
+		})
+		if err == nil {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("CallObject still failing after 30s: %v", err)
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+
+	result := &structpb.Struct{}
+	if err := callResp.Response.UnmarshalTo(result); err != nil {
+		t.Fatalf("UnmarshalTo response: %v", err)
+	}
+	if !result.Fields["authenticated"].GetBoolValue() {
+		t.Fatal("expected authenticated=true — CallerIdentity was nil in object method")
+	}
+	if got := result.Fields["userID"].GetStringValue(); got != "alice" {
+		t.Errorf("userID: want %q, got %q", "alice", got)
+	}
+	gotRoles := result.Fields["roles"].GetListValue().GetValues()
+	if len(gotRoles) != 2 {
+		t.Fatalf("roles len: want 2, got %d", len(gotRoles))
+	}
+	for i, want := range []string{"admin", "viewer"} {
+		if got := gotRoles[i].GetStringValue(); got != want {
+			t.Errorf("roles[%d]: want %q, got %q", i, want, got)
+		}
+	}
+}
+
+// TestGateAuth_ExpiredJWT verifies that an expired token is rejected at Register
+// with codes.Unauthenticated.
+func TestGateAuth_ExpiredJWT(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.Skip("Skipping long-running integration test in short mode")
+	}
+
+	ctx := context.Background()
+	etcdPrefix := testutil.PrepareEtcdPrefix(t, "localhost:2379")
+
+	gateAddr := testutil.GetFreeAddress()
+	gateServer, err := NewGateServer(&GateServerConfig{
+		ListenAddress:    gateAddr,
+		AdvertiseAddress: gateAddr,
+		EtcdAddress:      "localhost:2379",
+		EtcdPrefix:       etcdPrefix,
+		NumShards:        testutil.TestNumShards,
+		AuthValidator:    authjwt.New(authjwt.Options{SigningKey: jwtTestKey}),
+	})
+	if err != nil {
+		t.Skipf("etcd not available: %v", err)
+	}
+	t.Cleanup(func() { gateServer.Stop() })
+	if err := gateServer.Start(ctx); err != nil {
+		t.Fatalf("gateServer.Start: %v", err)
+	}
+
+	conn, err := grpc.NewClient(gateAddr, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		t.Fatalf("grpc.NewClient: %v", err)
+	}
+	t.Cleanup(func() { conn.Close() })
+	gateClient := gate_pb.NewGateServiceClient(conn)
+
+	expiredToken := makeToken(jwtTestKey, "alice", nil, time.Now().Add(-time.Hour))
+	regMD := metadata.Pairs("authorization", "Bearer "+expiredToken)
+	regCtx := metadata.NewOutgoingContext(ctx, regMD)
+	stream, err := gateClient.Register(regCtx, &gate_pb.Empty{})
+	if err != nil {
+		// gRPC may reject immediately
+		if s, ok := status.FromError(err); ok && s.Code() == codes.Unauthenticated {
+			return
+		}
+		t.Fatalf("Register unexpected error: %v", err)
+	}
+	_, err = stream.Recv()
+	if err == nil {
+		t.Fatal("expected error for expired token, got nil")
+	}
+	if s, ok := status.FromError(err); ok {
+		if s.Code() != codes.Unauthenticated {
+			t.Errorf("want codes.Unauthenticated, got %v", s.Code())
+		}
+	}
+}
+
+// TestGateAuth_MissingToken verifies that a connection with no authorization
+// header is rejected with codes.Unauthenticated.
+func TestGateAuth_MissingToken(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.Skip("Skipping long-running integration test in short mode")
+	}
+
+	ctx := context.Background()
+	etcdPrefix := testutil.PrepareEtcdPrefix(t, "localhost:2379")
+
+	gateAddr := testutil.GetFreeAddress()
+	gateServer, err := NewGateServer(&GateServerConfig{
+		ListenAddress:    gateAddr,
+		AdvertiseAddress: gateAddr,
+		EtcdAddress:      "localhost:2379",
+		EtcdPrefix:       etcdPrefix,
+		NumShards:        testutil.TestNumShards,
+		AuthValidator:    authjwt.New(authjwt.Options{SigningKey: jwtTestKey}),
+	})
+	if err != nil {
+		t.Skipf("etcd not available: %v", err)
+	}
+	t.Cleanup(func() { gateServer.Stop() })
+	if err := gateServer.Start(ctx); err != nil {
+		t.Fatalf("gateServer.Start: %v", err)
+	}
+
+	conn, err := grpc.NewClient(gateAddr, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		t.Fatalf("grpc.NewClient: %v", err)
+	}
+	t.Cleanup(func() { conn.Close() })
+	gateClient := gate_pb.NewGateServiceClient(conn)
+
+	// Register with no auth metadata
+	stream, err := gateClient.Register(ctx, &gate_pb.Empty{})
+	if err != nil {
+		if s, ok := status.FromError(err); ok && s.Code() == codes.Unauthenticated {
+			return
+		}
+		t.Fatalf("Register unexpected error: %v", err)
+	}
+	_, err = stream.Recv()
+	if err == nil {
+		t.Fatal("expected error for missing token, got nil")
+	}
+	if s, ok := status.FromError(err); ok {
+		if s.Code() != codes.Unauthenticated {
+			t.Errorf("want codes.Unauthenticated, got %v", s.Code())
+		}
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/coreos/go-semver v0.3.1 // indirect
 	github.com/coreos/go-systemd/v22 v22.5.0 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
+	github.com/golang-jwt/jwt/v5 v5.3.1 // indirect
 	github.com/golang/protobuf v1.5.4 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.26.3 // indirect
 	github.com/kylelemons/godebug v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -15,6 +15,8 @@ github.com/go-logr/stdr v1.2.2/go.mod h1:mMo/vtBO5dYbehREoey6XUKy/eSumjCCveDpRre
 github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
+github.com/golang-jwt/jwt/v5 v5.3.1 h1:kYf81DTWFe7t+1VvL7eS+jKFVWaUnK9cB1qbwn63YCY=
+github.com/golang-jwt/jwt/v5 v5.3.1/go.mod h1:fxCRLWMO43lRc8nhHWY6LGqRcf+1gQWArsqaEUEa5bE=
 github.com/golang/protobuf v1.5.4 h1:i7eJL8qZTpSEXOPTxNKhASYpMn+8e5Q6AdndVa1dWek=
 github.com/golang/protobuf v1.5.4/go.mod h1:lnTiLA8Wa4RWRcIUkrtSVa5nRhsEGBg48fD6rSs7xps=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=

--- a/goverseapi/authjwt/authjwt.go
+++ b/goverseapi/authjwt/authjwt.go
@@ -1,0 +1,129 @@
+// Package authjwt provides an AuthValidator that verifies JWT bearer tokens.
+//
+// Supported algorithms: HS256, HS384, HS512 (HMAC) and RS256, RS384, RS512
+// (RSA) and ES256, ES384, ES512 (ECDSA). The token is read from the
+// "authorization" key in the headers map (gRPC metadata convention) or the
+// "Authorization" key (HTTP header convention); both are checked.
+//
+// The JWT "sub" claim is mapped to CallerIdentity.UserID. If the token
+// contains a "roles" claim (array of strings), those values are mapped to
+// CallerIdentity.Roles.
+//
+// Example — HMAC shared secret:
+//
+//	cfg := &gateserver.GateServerConfig{
+//	    AuthValidator: authjwt.New(authjwt.Options{
+//	        SigningKey: []byte("my-secret"),
+//	    }),
+//	}
+//
+// Example — RSA public key:
+//
+//	pubKey, _ := jwt.ParseRSAPublicKeyFromPEM(pemBytes)
+//	cfg := &gateserver.GateServerConfig{
+//	    AuthValidator: authjwt.New(authjwt.Options{
+//	        SigningKey: pubKey,
+//	        Issuer:    "https://auth.example.com",
+//	        Audience:  []string{"my-service"},
+//	    }),
+//	}
+package authjwt
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/xiaonanln/goverse/util/callcontext"
+)
+
+// Options configure the JWT validator.
+type Options struct {
+	// SigningKey is the key used to verify the token signature.
+	// For HMAC algorithms (HS256/HS384/HS512) use []byte.
+	// For RSA algorithms (RS256/RS384/RS512) use *rsa.PublicKey.
+	// For ECDSA algorithms (ES256/ES384/ES512) use *ecdsa.PublicKey.
+	// Required.
+	SigningKey interface{}
+
+	// Issuer, if non-empty, requires the token's "iss" claim to match.
+	Issuer string
+
+	// Audience, if non-empty, requires the token's "aud" claim to include
+	// at least one of the listed values.
+	Audience []string
+
+	// ClockSkew is the maximum allowed difference between the token's
+	// expiry and the current time. Defaults to 0 (no skew allowed).
+	ClockSkew time.Duration
+}
+
+type validator struct {
+	opts Options
+}
+
+// New returns an AuthValidator that verifies JWT bearer tokens using opts.
+func New(opts Options) *validator {
+	return &validator{opts: opts}
+}
+
+// goverseClaims extends RegisteredClaims with an optional "roles" array.
+type goverseClaims struct {
+	Roles []string `json:"roles,omitempty"`
+	jwt.RegisteredClaims
+}
+
+// Validate implements callcontext.AuthValidator.
+//
+// headers is the union of request headers (HTTP) or gRPC metadata (lowercase
+// keys). The bearer token is read from the "authorization" key.
+func (v *validator) Validate(_ context.Context, headers map[string][]string) (*callcontext.CallerIdentity, error) {
+	raw := bearerToken(headers)
+	if raw == "" {
+		return nil, fmt.Errorf("missing or empty Authorization header")
+	}
+
+	parserOpts := []jwt.ParserOption{
+		jwt.WithLeeway(v.opts.ClockSkew),
+	}
+	if v.opts.Issuer != "" {
+		parserOpts = append(parserOpts, jwt.WithIssuer(v.opts.Issuer))
+	}
+	if len(v.opts.Audience) > 0 {
+		for _, aud := range v.opts.Audience {
+			parserOpts = append(parserOpts, jwt.WithAudience(aud))
+		}
+	}
+
+	claims := &goverseClaims{}
+	_, err := jwt.ParseWithClaims(raw, claims, func(token *jwt.Token) (interface{}, error) {
+		return v.opts.SigningKey, nil
+	}, parserOpts...)
+	if err != nil {
+		return nil, fmt.Errorf("invalid token: %w", err)
+	}
+
+	sub, err := claims.GetSubject()
+	if err != nil || sub == "" {
+		return nil, fmt.Errorf("token missing sub claim")
+	}
+
+	return &callcontext.CallerIdentity{
+		UserID: sub,
+		Roles:  claims.Roles,
+	}, nil
+}
+
+// bearerToken extracts the raw JWT from headers["authorization"] or
+// headers["Authorization"], stripping the "Bearer " prefix.
+func bearerToken(headers map[string][]string) string {
+	for _, key := range []string{"authorization", "Authorization"} {
+		vals := headers[key]
+		if len(vals) > 0 && vals[0] != "" {
+			return strings.TrimPrefix(vals[0], "Bearer ")
+		}
+	}
+	return ""
+}

--- a/goverseapi/authjwt/authjwt_test.go
+++ b/goverseapi/authjwt/authjwt_test.go
@@ -1,0 +1,223 @@
+package authjwt_test
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/rsa"
+	"testing"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/xiaonanln/goverse/goverseapi/authjwt"
+)
+
+var ctx = context.Background()
+
+func signHS256(key []byte, sub string, roles []string, expiry time.Time) string {
+	claims := jwt.MapClaims{"sub": sub, "exp": expiry.Unix()}
+	if len(roles) > 0 {
+		claims["roles"] = roles
+	}
+	tok, _ := jwt.NewWithClaims(jwt.SigningMethodHS256, claims).SignedString(key)
+	return tok
+}
+
+func TestNew_HMACValidToken(t *testing.T) {
+	key := []byte("supersecret")
+	v := authjwt.New(authjwt.Options{SigningKey: key})
+
+	token := signHS256(key, "alice", nil, time.Now().Add(time.Hour))
+	id, err := v.Validate(ctx, map[string][]string{
+		"authorization": {"Bearer " + token},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if id.UserID != "alice" {
+		t.Errorf("want UserID=alice, got %q", id.UserID)
+	}
+}
+
+func TestNew_HMACWithRoles(t *testing.T) {
+	key := []byte("supersecret")
+	v := authjwt.New(authjwt.Options{SigningKey: key})
+
+	token := signHS256(key, "bob", []string{"admin", "editor"}, time.Now().Add(time.Hour))
+	id, err := v.Validate(ctx, map[string][]string{
+		"authorization": {"Bearer " + token},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if id.UserID != "bob" {
+		t.Errorf("want UserID=bob, got %q", id.UserID)
+	}
+	if len(id.Roles) != 2 || id.Roles[0] != "admin" || id.Roles[1] != "editor" {
+		t.Errorf("unexpected roles: %v", id.Roles)
+	}
+}
+
+func TestNew_ExpiredToken(t *testing.T) {
+	key := []byte("supersecret")
+	v := authjwt.New(authjwt.Options{SigningKey: key})
+
+	token := signHS256(key, "alice", nil, time.Now().Add(-time.Hour))
+	_, err := v.Validate(ctx, map[string][]string{
+		"authorization": {"Bearer " + token},
+	})
+	if err == nil {
+		t.Fatal("expected error for expired token, got nil")
+	}
+}
+
+func TestNew_WrongSigningKey(t *testing.T) {
+	key1 := []byte("key1")
+	key2 := []byte("key2")
+	v := authjwt.New(authjwt.Options{SigningKey: key2})
+
+	token := signHS256(key1, "alice", nil, time.Now().Add(time.Hour))
+	_, err := v.Validate(ctx, map[string][]string{
+		"authorization": {"Bearer " + token},
+	})
+	if err == nil {
+		t.Fatal("expected error for wrong signing key, got nil")
+	}
+}
+
+func TestNew_MissingAuthorizationHeader(t *testing.T) {
+	v := authjwt.New(authjwt.Options{SigningKey: []byte("k")})
+	_, err := v.Validate(ctx, map[string][]string{})
+	if err == nil {
+		t.Fatal("expected error for missing header, got nil")
+	}
+}
+
+func TestNew_IssuerMismatch(t *testing.T) {
+	key := []byte("supersecret")
+	v := authjwt.New(authjwt.Options{
+		SigningKey: key,
+		Issuer:     "https://expected.example.com",
+	})
+
+	claims := jwt.MapClaims{
+		"sub": "alice",
+		"iss": "https://other.example.com",
+		"exp": time.Now().Add(time.Hour).Unix(),
+	}
+	token, _ := jwt.NewWithClaims(jwt.SigningMethodHS256, claims).SignedString(key)
+	_, err := v.Validate(ctx, map[string][]string{
+		"authorization": {"Bearer " + token},
+	})
+	if err == nil {
+		t.Fatal("expected error for issuer mismatch, got nil")
+	}
+}
+
+func TestNew_IssuerMatch(t *testing.T) {
+	key := []byte("supersecret")
+	issuer := "https://auth.example.com"
+	v := authjwt.New(authjwt.Options{
+		SigningKey: key,
+		Issuer:     issuer,
+	})
+
+	claims := jwt.MapClaims{
+		"sub": "carol",
+		"iss": issuer,
+		"exp": time.Now().Add(time.Hour).Unix(),
+	}
+	token, _ := jwt.NewWithClaims(jwt.SigningMethodHS256, claims).SignedString(key)
+	id, err := v.Validate(ctx, map[string][]string{
+		"authorization": {"Bearer " + token},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if id.UserID != "carol" {
+		t.Errorf("want carol, got %q", id.UserID)
+	}
+}
+
+func TestNew_ClockSkew(t *testing.T) {
+	key := []byte("supersecret")
+	skew := 30 * time.Second
+	v := authjwt.New(authjwt.Options{SigningKey: key, ClockSkew: skew})
+
+	// Token expired 10 seconds ago, within skew window
+	token := signHS256(key, "alice", nil, time.Now().Add(-10*time.Second))
+	id, err := v.Validate(ctx, map[string][]string{
+		"authorization": {"Bearer " + token},
+	})
+	if err != nil {
+		t.Fatalf("expected token within skew to pass: %v", err)
+	}
+	if id.UserID != "alice" {
+		t.Errorf("want alice, got %q", id.UserID)
+	}
+}
+
+func TestNew_RSAToken(t *testing.T) {
+	privKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("rsa.GenerateKey: %v", err)
+	}
+	v := authjwt.New(authjwt.Options{SigningKey: privKey.Public()})
+
+	claims := jwt.MapClaims{"sub": "dave", "exp": time.Now().Add(time.Hour).Unix()}
+	token, err := jwt.NewWithClaims(jwt.SigningMethodRS256, claims).SignedString(privKey)
+	if err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+
+	id, err := v.Validate(ctx, map[string][]string{
+		"authorization": {"Bearer " + token},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if id.UserID != "dave" {
+		t.Errorf("want dave, got %q", id.UserID)
+	}
+}
+
+func TestNew_ECDSAToken(t *testing.T) {
+	privKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("ecdsa.GenerateKey: %v", err)
+	}
+	v := authjwt.New(authjwt.Options{SigningKey: privKey.Public()})
+
+	claims := jwt.MapClaims{"sub": "eve", "exp": time.Now().Add(time.Hour).Unix()}
+	token, err := jwt.NewWithClaims(jwt.SigningMethodES256, claims).SignedString(privKey)
+	if err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+
+	id, err := v.Validate(ctx, map[string][]string{
+		"authorization": {"Bearer " + token},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if id.UserID != "eve" {
+		t.Errorf("want eve, got %q", id.UserID)
+	}
+}
+
+func TestNew_UpperCaseAuthorizationHeader(t *testing.T) {
+	key := []byte("k")
+	v := authjwt.New(authjwt.Options{SigningKey: key})
+	token := signHS256(key, "frank", nil, time.Now().Add(time.Hour))
+	// HTTP sends "Authorization" (capital A)
+	id, err := v.Validate(ctx, map[string][]string{
+		"Authorization": {"Bearer " + token},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if id.UserID != "frank" {
+		t.Errorf("want frank, got %q", id.UserID)
+	}
+}

--- a/goverseapi/authnone/authnone.go
+++ b/goverseapi/authnone/authnone.go
@@ -1,0 +1,26 @@
+// Package authnone provides an AuthValidator that always succeeds with an
+// empty CallerIdentity. Use it during local development when you want the
+// gate auth plumbing to be exercised without requiring a real token provider.
+//
+// Example:
+//
+//	cfg := &gateserver.GateServerConfig{
+//	    AuthValidator: authnone.New(),
+//	}
+package authnone
+
+import (
+	"context"
+
+	"github.com/xiaonanln/goverse/util/callcontext"
+)
+
+type validator struct{}
+
+// New returns an AuthValidator that accepts every connection and stamps an
+// empty CallerIdentity onto it. CallerUserID(ctx) will return "" for all calls.
+func New() *validator { return &validator{} }
+
+func (v *validator) Validate(_ context.Context, _ map[string][]string) (*callcontext.CallerIdentity, error) {
+	return &callcontext.CallerIdentity{}, nil
+}

--- a/server/server.go
+++ b/server/server.go
@@ -650,6 +650,9 @@ func (server *Server) RegisterGate(req *goverse_pb.RegisterGateRequest, stream g
 func (server *Server) ReliableCallObject(ctx context.Context, req *goverse_pb.ReliableCallObjectRequest) (*goverse_pb.ReliableCallObjectResponse, error) {
 	server.logRPC("ReliableCallObject", req)
 
+	// Re-inject CallerIdentity forwarded by the originating node as gRPC metadata.
+	ctx = callcontext.ExtractCallerFromIncoming(ctx)
+
 	// Validate request parameters - require the new fields
 	// Return SKIPPED status for validation errors since method was never executed
 	if req.GetCallId() == "" {


### PR DESCRIPTION
## Summary

- **`goverseapi/authjwt`**: JWT bearer token validator (HS256/RS256/ES256). Reads `authorization: Bearer <token>` header/metadata, extracts `sub` → `UserID`, optional `roles` → `Roles`. Configurable issuer, audience, clock-skew.
- **`goverseapi/authnone`**: No-op validator for local development — accepts all connections with an empty identity so the auth plumbing is exercised without a real token provider.
- **`ReliableCallObject` identity propagation**: Two-line fix — `cluster.go` now calls `InjectCallerToOutgoing` before the remote RPC (matching `CallObject`); `server.go` now calls `ExtractCallerFromIncoming` in the `ReliableCallObject` handler (matching the `CallObject` handler).
- **`gate_auth_integration_test.go`**: Full-stack JWT tests — valid token accepted + identity flows to object method, expired token rejected with `Unauthenticated`, missing token rejected with `Unauthenticated`.

This completes Item 2 from the v0.2 trust-boundary design (`docs/design/V0_2_TRUST_BOUNDARY.md`). All items 2 and 4 are now done.

## Test plan

- [ ] `go test ./goverseapi/authjwt/...` — 11 unit tests (HMAC/RSA/ECDSA, expiry, issuer, clock skew, header case)
- [ ] `go test ./goverseapi/authnone/...` — compiles cleanly (no test files needed for a 5-line no-op)
- [ ] `go test ./gate/gateserver/... -run TestGateAuth` (requires etcd) — 3 integration tests
- [ ] `go build ./...` — clean build

🤖 Generated with [Claude Code](https://claude.com/claude-code)