### PR TITLE
feat(bomberman): wait for cluster ready before launching stress clients

### DIFF
--- a/samples/bomberman/stress_test.py
+++ b/samples/bomberman/stress_test.py
@@ -99,29 +99,28 @@ def wait_for_cluster_ready(gate_port: int, timeout: float = 60.0) -> bool:
     deadline = time.time() + timeout
     attempt = 0
     print(f"Waiting for cluster to be ready (probe: Player-{probe_player} via port {gate_port})...")
-    client: Optional[Client] = None
-    try:
-        client = Client([f"localhost:{gate_port}"], ClientOptions(call_timeout=3.0))
-        client.connect(timeout=10.0)
-        while time.time() < deadline:
-            attempt += 1
-            try:
-                resp_any = client.call_object(
-                    "Player", f"Player-{probe_player}", "GetStats", req, timeout=3.0
-                )
-                if resp_any is not None:
-                    elapsed = timeout - (deadline - time.time())
-                    print(f"✅ Cluster ready after {elapsed:.1f}s ({attempt} probe(s))")
-                    return True
-            except Exception:
-                pass
-            time.sleep(0.5)
-    finally:
-        if client is not None:
-            try:
-                client.close()
-            except Exception:
-                pass
+    while time.time() < deadline:
+        attempt += 1
+        client: Optional[Client] = None
+        try:
+            client = Client([f"localhost:{gate_port}"], ClientOptions(call_timeout=3.0))
+            client.connect(timeout=3.0)
+            resp_any = client.call_object(
+                "Player", f"Player-{probe_player}", "GetStats", req, timeout=3.0
+            )
+            if resp_any is not None:
+                elapsed = timeout - (deadline - time.time())
+                print(f"✅ Cluster ready after {elapsed:.1f}s ({attempt} probe(s))")
+                return True
+        except Exception:
+            pass
+        finally:
+            if client is not None:
+                try:
+                    client.close()
+                except Exception:
+                    pass
+        time.sleep(0.5)
     print(f"❌ Cluster not ready after {timeout}s ({attempt} probes)")
     return False
 

--- a/samples/bomberman/stress_test.py
+++ b/samples/bomberman/stress_test.py
@@ -84,6 +84,48 @@ MIN_REJOIN_DELAY = 0.0
 MAX_REJOIN_DELAY = 0.5
 
 
+def wait_for_cluster_ready(gate_port: int, timeout: float = 60.0) -> bool:
+    """Poll Player.GetStats for a probe player until the cluster is ready.
+
+    The gate and nodes start asynchronously — shards have a TargetNode
+    assigned by the leader but CurrentNode is empty until each node claims
+    ownership. During that window every CallObject returns an error. This
+    function spins until one GetStats call succeeds (or timeout expires),
+    ensuring clients don't start generating rpc_errors while the cluster
+    is still warming up.
+    """
+    probe_player = "stress-player-000"
+    req = bomberman_pb2.GetPlayerStatsRequest()
+    deadline = time.time() + timeout
+    attempt = 0
+    print(f"Waiting for cluster to be ready (probe: Player-{probe_player} via port {gate_port})...")
+    client: Optional[Client] = None
+    try:
+        client = Client([f"localhost:{gate_port}"], ClientOptions(call_timeout=3.0))
+        client.connect(timeout=10.0)
+        while time.time() < deadline:
+            attempt += 1
+            try:
+                resp_any = client.call_object(
+                    "Player", f"Player-{probe_player}", "GetStats", req, timeout=3.0
+                )
+                if resp_any is not None:
+                    elapsed = timeout - (deadline - time.time())
+                    print(f"✅ Cluster ready after {elapsed:.1f}s ({attempt} probe(s))")
+                    return True
+            except Exception:
+                pass
+            time.sleep(0.5)
+    finally:
+        if client is not None:
+            try:
+                client.close()
+            except Exception:
+                pass
+    print(f"❌ Cluster not ready after {timeout}s ({attempt} probes)")
+    return False
+
+
 def probe_http_gate(http_url: str, timeout: float = 5.0) -> bool:
     """Open an SSE connection to the gate's /api/v1/events/stream and
     assert we get the expected `event: register` greeting within timeout
@@ -450,12 +492,14 @@ def main() -> int:
             gw.start()
             gateways.append(gw)
 
-        time.sleep(2)
-
         if http_gate_url is not None:
             if not probe_http_gate(http_gate_url):
                 print("❌ HTTP gate probe failed — aborting before clients connect")
                 return 1
+
+        if not wait_for_cluster_ready(gate_ports[0]):
+            print("❌ Cluster not ready — aborting before clients connect")
+            return 1
 
         print("\n" + "=" * 80)
         print(f"LAUNCHING {args.clients} CLIENTS FOR {args.duration}s")


### PR DESCRIPTION
## Summary

- Replaces the fixed `time.sleep(2)` after gate start with a `wait_for_cluster_ready()` poll loop
- Probes `Player.GetStats` for `stress-player-000` through the first gate port until the call succeeds
- Eliminates ~400 startup `rpc_errors` that fired while shards had `TargetNode` assigned but `CurrentNode` still empty (unclaimed)
- Times out after 60s so CI still fails fast if the cluster never comes up

## Test plan

- [ ] Run `python samples/bomberman/stress_test.py` — `rpc_errors` at startup should be 0 (or near 0)
- [ ] Confirm "Cluster ready after X.Xs" message appears before "LAUNCHING N CLIENTS"
- [ ] Confirm test still passes end-to-end with `✅ bomberman stress test passed`

🤖 Generated with [Claude Code](https://claude.ai/claude-code)