### PR TITLE
fix(server): save objects before revoking etcd lease on shutdown

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -386,14 +386,18 @@ func (server *Server) Run(ctx context.Context) error {
 		server.logger.Errorf("gRPC server error: %v", err)
 	}
 
-	err = server.cluster.Stop(server.ctx)
-	if err != nil {
-		server.logger.Errorf("Failed to stop cluster: %v", err)
-	}
-
+	// Save all objects to Postgres before revoking the etcd lease so that
+	// other nodes claiming our shards always load up-to-date state.
 	err = node.Stop(server.ctx)
 	if err != nil {
 		server.logger.Errorf("Failed to stop node: %v", err)
+	}
+
+	// Revoke the etcd lease after objects are persisted so the cluster
+	// immediately redistributes our shards without a lease-TTL wait.
+	err = server.cluster.Stop(server.ctx)
+	if err != nil {
+		server.logger.Errorf("Failed to stop cluster: %v", err)
 	}
 
 	server.logger.Infof("gRPC server stopped")


### PR DESCRIPTION
## Summary

- Swaps `node.Stop()` and `cluster.Stop()` call order in `server/server.go`
- Objects are now saved to Postgres **before** the etcd lease is revoked
- Previously, other nodes could claim our shards and load stale object state from Postgres during the window between lease revocation and the save completing

Implements the fix described in `docs/design/NODE_SHUTDOWN.md` §4.1 and §6.

## Test plan

- [x] `go test ./server/...` passes
- [x] Build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)