### PR TITLE
docs: update NODE_SHUTDOWN with status, priorities, and in-flight behaviour

### DIFF
--- a/docs/design/NODE_SHUTDOWN.md
+++ b/docs/design/NODE_SHUTDOWN.md
@@ -1,6 +1,6 @@
 # Node Graceful Shutdown
 
-> **Status**: Not started.
+> **Status**: Core fix done (#581). Leader resignation pending.
 
 ---
 
@@ -12,7 +12,7 @@ no lease-TTL wait.
 
 ---
 
-## 2. Current behaviour
+## 2. Current behaviour (before fix)
 
 `server.Run()` shutdown sequence on SIGTERM:
 
@@ -26,20 +26,19 @@ no lease-TTL wait.
 nodes start claiming this node's shards right away. But objects haven't been
 saved yet — other nodes load stale state from Postgres.
 
-In addition, other nodes must wait for the etcd lease TTL before seeing the
-node as gone... Actually no — `cluster.Stop()` already calls `Revoke()` on
-the lease (`etcdmanager.UnregisterKeyLease` → `client.Revoke()`), so
-**proactive removal is already in place**. The only bug is the ordering.
+`cluster.Stop()` already calls `Revoke()` on the lease
+(`etcdmanager.UnregisterKeyLease` → `client.Revoke()`), so proactive removal
+is already in place. The only bug was the ordering.
 
 ---
 
 ## 3. Scenarios
 
-| Scenario | Current issue | After fix |
+| Scenario | Before fix | After fix |
 | --- | --- | --- |
-| **Planned restart (same node ID)** | Lease revoked → 2 rounds of shard migration | Same. Downside accepted: if node restarts fast enough (<TTL), not revoking would be zero-migration. But consistent behaviour is simpler. |
-| **Version upgrade / downgrade** | Stale Postgres state race | Fixed: state saved before lease revoked |
-| **Scale down (permanent)** | Stale Postgres state race | Fixed |
+| **Planned restart (same node ID)** | Lease revoked → 2 rounds of shard migration | Same. Accepted: consistent behaviour is simpler than conditional revocation. |
+| **Version upgrade / downgrade** | Stale Postgres state race | ✅ Fixed: state saved before lease revoked |
+| **Scale down (permanent)** | Stale Postgres state race | ✅ Fixed |
 | **Hard crash** | No SIGTERM → lease TTL wait (~15s) | Unchanged — cannot fix with shutdown code |
 | **Scale up (add node)** | Not related to shutdown | Unaffected |
 
@@ -47,31 +46,35 @@ the lease (`etcdmanager.UnregisterKeyLease` → `client.Revoke()`), so
 
 ## 4. Design
 
-### 4.1 Corrected shutdown order
+### 4.1 Corrected shutdown order ✅ Done — #581 (P0)
 
 ```
 SIGTERM received
-  1. grpcServer.Stop()        — reject new RPCs; in-flight complete via stopMu
-  2. node.Stop()              — wait for in-flight, save all objects to Postgres,
-                                destroy objects
+  1. grpcServer.Stop()        — reject new RPCs; in-flight forwarded calls cancelled via ctx
+  2. node.Stop()              — wait for handler goroutines to exit (stopMu.Lock),
+                                save all objects to Postgres, destroy objects
   3. cluster.Stop()           — revoke etcd lease (immediate removal from cluster)
   4. process exits
 ```
 
-The fix is moving step 2 and 3: **save before revoke**.
+The fix: **save before revoke** (`node.Stop` and `cluster.Stop` swapped in `server/server.go`).
 
-### 4.2 Why in-flight calls are safe
+### 4.2 In-flight call behaviour
 
-`node.Stop()` sets `stopped = true` and then acquires `stopMu` as a write lock.
-All RPC handlers hold `stopMu` as a read lock while running. So `node.Stop()`
-waits for all in-flight handlers to return before proceeding to `saveAllObjectsLocked`.
-No call is aborted mid-flight.
+`grpcServer.Stop()` cancels handler contexts immediately. Two cases:
+
+- **Forwarded calls** (gRPC to another node): context cancellation causes the
+  call to return an error. Caller receives an error and can retry. `ReliableCallObject`
+  handles this transparently.
+- **Local object operations** (in-process): do not check context; run to
+  completion. `stopMu.Lock()` in `node.Stop()` waits for all handler goroutines
+  to exit before saving, so saved state is always self-consistent.
 
 ### 4.3 Object persistence
 
 `node.Stop()` already calls `saveAllObjectsLocked()` which writes every active
 object's state to Postgres via `provider.SaveObject()` (upsert on `goverse_objects`
-table). This is covered by `TestStop_ObjectsPersistedBeforeClearing`.
+table). Covered by `TestStop_ObjectsPersistedBeforeClearing`.
 
 ### 4.4 Etcd removal
 
@@ -84,41 +87,36 @@ no waiting for the 15s `NodeLeaseTTL`. The leader's etcd watch fires and
 
 ## 5. Known limitations / TODOs
 
-### 5.1 Leader resignation (TODO)
+### 5.1 Leader resignation — P2, not done
 
 If the shutting-down node is the consensus leader, it should resign before
-removing itself from etcd to ensure another node cleanly takes over the watch
-loop. Without this, there is a brief window where leadership is in flux.
+`cluster.Stop()` removes itself from etcd. Without this, there is a brief
+window where no node is running the shard-assignment watch loop, potentially
+delaying shard redistribution.
 
-This is deferred — the current fix is still a net improvement even without it.
+Requires investigation in `consensusmanager/` to find the resign hook. Low
+urgency — the cluster self-heals when another node wins the election, and the
+window is typically sub-second.
 
-### 5.2 Hard crash
+### 5.2 Hard crash — out of scope
 
 Hard crashes (OOM, kernel kill, `SIGKILL`) bypass all shutdown code. The only
-recovery mechanism is the etcd lease TTL (15s by default). This is not fixable
-at the application level; a shorter TTL reduces the window at the cost of more
-aggressive keepalives. Out of scope here.
+recovery mechanism is the etcd lease TTL (15s by default). Not fixable at the
+application level; a shorter TTL reduces the window at the cost of more
+aggressive keepalives.
 
-### 5.3 Planned restart with same node ID
+### 5.3 Planned restart with same node ID — P3, accepted tradeoff
 
 If a node restarts with the same ID and comes back within the lease TTL,
-revoking the lease causes two unnecessary rounds of shard migration. The
-alternative (not revoking) would be zero-migration on fast restarts but is
-harder to reason about. The current design accepts the trade-off in favour of
-simplicity and consistency.
+revoking the lease causes two unnecessary rounds of shard migration. Not
+revoking would be zero-migration on fast restarts but is harder to reason
+about. Current design accepts the trade-off in favour of simplicity.
 
 ---
 
-## 6. Implementation
+## 6. Implementation summary
 
-**File:** `server/server.go`
-
-Swap `cluster.Stop()` and `node.Stop()` call order. No other changes needed —
-all the individual mechanisms (object save, lease revoke) are already
-implemented.
-
-**Approx LOC:** ~5 (reorder + comments).
-
-**Tests:** Existing `TestStop_ObjectsPersistedBeforeClearing` covers the node
-persistence invariant. An integration test verifying the full ordering under
-real etcd is desirable but not required for the initial fix.
+| Item | File | LOC | Status |
+| --- | --- | --- | --- |
+| Swap shutdown order (§4.1) | `server/server.go` | ~5 | ✅ Done — #581 |
+| Leader resignation (§5.1) | `consensusmanager/` | TBD | ⏳ Not started |


### PR DESCRIPTION
## Summary

- Mark §4.1 (shutdown order fix) as ✅ Done — #581
- Add P0/P2/P3 priority labels to all items
- Clarify in-flight call behaviour: forwarded calls are cancelled by `grpcServer.Stop()`, local object operations run to completion
- Update "Current behaviour" section to be past-tense (bug is fixed)
- Add implementation summary table

🤖 Generated with [Claude Code](https://claude.com/claude-code)